### PR TITLE
v1.11.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 #CHANGELOG
 
+## [1.11.54] - 2020-04-10
+
+### Added
+
+- French translation
+- When importing a database, the app will ask whether to overwrite the existing database (closes #91)
+
+### Changed
+
+- When you delete a file, it is no longer moved to the trash but deleted outright. (Moving to trash seems to fail randomly; so sometimes it was impossible to delete a file.)
+
+### Fixed
+
+- Always treat password fields as protected (libkeepass/pykeepass#194) [thanks, Robin]
+- Changed master key was not remembered when it should have been
+- Adding databases with mixed-case extensions, such as all-caps .KDBX [thanks, Thorsten]
+- When moving groups/entries, their timestamps were updated incorrectly, and the move was rolled back when merging with an earlier version of the database [thanks, Daniel]
+- Updating master key modification timestamp once it's been changed
+- Sometimes it was impossible to delete files
+- Infinite clipboard timeout was treated as immediate [thanks, Andreas]
+- Backup files are no longer counted towards free 1-database limit
+- Hard-coded absolute path in contents.xcworkspacedata (fixes #90)
+- Showing and re-hiding a password sometimes produced colored asterisks
+- Minor translation fixes
+
+
 ## [1.10.53] - 2020-01-19
 
 ### Fixed

--- a/KeePassium AutoFill/MainCoordinator.swift
+++ b/KeePassium AutoFill/MainCoordinator.swift
@@ -377,7 +377,8 @@ extension MainCoordinator: DatabaseChooserDelegate {
     
     func databaseChooserShouldAddDatabase(_ sender: DatabaseChooserVC, popoverAnchor: PopoverAnchor) {
         watchdog.restart()
-        if sender.databaseRefs.count > 0 {
+        let nonBackupDatabaseRefs = sender.databaseRefs.filter { $0.location != .internalBackup }
+        if nonBackupDatabaseRefs.count > 0 {
             if PremiumManager.shared.isAvailable(feature: .canUseMultipleDatabases) {
                 addDatabase(popoverAnchor: popoverAnchor)
             } else {
@@ -663,6 +664,7 @@ extension MainCoordinator: LongPressAwareNavigationControllerDelegate {
 
 extension MainCoordinator: EntryFinderDelegate {
     func entryFinder(_ sender: EntryFinderVC, didSelectEntry entry: Entry) {
+        entry.touch(.accessed)
         returnCredentials(entry: entry)
     }
     

--- a/KeePassium AutoFill/controllers/EntryFinderVC.swift
+++ b/KeePassium AutoFill/controllers/EntryFinderVC.swift
@@ -102,7 +102,10 @@ class EntryFinderVC: UITableViewController {
         searchController.searchBar.returnKeyType = .search
         searchController.searchBar.barStyle = .default
         
-        searchController.dimsBackgroundDuringPresentation = false
+        if #available(iOS 12.0, *) {
+        } else {
+            searchController.dimsBackgroundDuringPresentation = false
+        }
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.searchResultsUpdater = self
         searchController.delegate = self

--- a/KeePassium AutoFill/controllers/fr.lproj/CrashReportVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/CrashReportVC.strings
@@ -1,0 +1,9 @@
+/* Class = "UIBarButtonItem"; title = "Close"; ObjectID = "ebS-pB-Qan"; */
+"ebS-pB-Qan.title" = "Fermer";
+
+/* Class = "UILabel"; text = "It seems that AutoFill did not close correctly the last time. \n\nThis can happen with large databases or memory-demanding database settings (Argon2).\n\nPlease contact us if you need help with this."; ObjectID = "kmV-si-Nrg"; */
+"kmV-si-Nrg.text" = "Il semble que le remplissage automatique ne s'est pas terminé correctement la dernière fois. \n\nCela peut se produire avec les bases de données volumineuse ou les paramètres de base de données exigeants en mémoire (Argon2).\n\nVeuillez nous contacter si vous avez besoin d'aide à ce sujet.";
+
+/* Class = "UINavigationItem"; title = "We are sorry"; ObjectID = "zvf-PV-5l4"; */
+"zvf-PV-5l4.title" = "Nous sommes désolés";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/DatabaseChooserVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/DatabaseChooserVC.strings
@@ -1,0 +1,9 @@
+/* Class = "UIBarButtonItem"; title = "Add Database"; ObjectID = "CbK-f7-To5"; Note = "Action"; */
+"CbK-f7-To5.title" = "Ajouter une base de données";
+
+/* Class = "UILabel"; text = "No recent databases"; ObjectID = "fXt-kp-oSe"; */
+"fXt-kp-oSe.text" = "Aucune base de données récente";
+
+/* Class = "UINavigationItem"; title = "Databases"; ObjectID = "Zun-me-VzS"; */
+"Zun-me-VzS.title" = "Bases de données";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/DatabaseUnlockerVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/DatabaseUnlockerVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UIButton"; normalTitle = "Unlock"; ObjectID = "89h-8b-LRO"; */
+"89h-8b-LRO.normalTitle" = "Déverrouiller";
+
+/* Class = "UIViewController"; title = "Unlock Database"; ObjectID = "bxv-kR-0w1"; */
+"bxv-kR-0w1.title" = "Déverrouiller la base de données";
+
+/* Class = "UITextField"; placeholder = "No Key File"; ObjectID = "Dnl-vm-GMg"; */
+"Dnl-vm-GMg.placeholder" = "Aucun fichier-clé";
+
+/* Class = "UITextField"; placeholder = "Password"; ObjectID = "U6j-Ph-AWS"; */
+"U6j-Ph-AWS.placeholder" = "Mot de passe";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/DiagnosticsViewerVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/DiagnosticsViewerVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UINavigationItem"; title = "Diagnostics"; ObjectID = "Ura-k4-GXq"; */
+"Ura-k4-GXq.title" = "Diagnostiques";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/EntryFinderVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/EntryFinderVC.strings
@@ -1,0 +1,9 @@
+/* Class = "UIBarButtonItem"; title = "Lock Database"; ObjectID = "dPB-bK-tzh"; Note = "Action "; */
+"dPB-bK-tzh.title" = "Verrouiller la base de données";
+
+/* Class = "UILabel"; text = "Nothing suitable found."; ObjectID = "NSB-dG-jRN"; Note = "Placeholder text for empty search results."; */
+"NSB-dG-jRN.text" = "Aucun résultat pertinent trouvé.";
+
+/* Class = "UILabel"; text = "Related Entries"; ObjectID = "yLY-eZ-iAh"; Note = "Title of a list of entries similar to (but not exactly matching) the search query."; */
+"yLY-eZ-iAh.text" = "Entrées liées";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/FirstSetupVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/FirstSetupVC.strings
@@ -1,0 +1,15 @@
+/* Class = "UIButton"; normalTitle = "Add Database"; ObjectID = "enW-gs-tra"; */
+"enW-gs-tra.normalTitle" = "Ajouter une base de données";
+
+/* Class = "UILabel"; text = "Please re-add databases and key files you want to use with the AutoFill feature."; ObjectID = "P0M-N3-ynf"; */
+"P0M-N3-ynf.text" = "Veuillez ajouter à nouveau les bases de données et les fichiers clés que vous souhaitez utiliser avec la fonction Remplissage automatique.";
+
+/* Class = "UILabel"; text = "AutoFill Setup"; ObjectID = "pIl-6L-Msp"; */
+"pIl-6L-Msp.text" = "AutoFill Setup";
+
+/* Class = "UINavigationItem"; title = "KeePassium"; ObjectID = "rzY-Ci-bd9"; */
+"rzY-Ci-bd9.title" = "KeePassium";
+
+/* Class = "UITextView"; text = "The AutoFill cannot automatically access the files you already have in the main KeePassium app.\n\nWhy? Behind the scenes, the system treats AutoFill as a separate app, independent from the main KeePassium process. For security reasons, an app cannot simply access any external files – unless you explicitly link these files to that app. Thus the system guarantees that the app can only access the few files you allowed it to.\n\nAs a result, both AutoFill and the main KeePassium app need to be given their own permissions for each external file. Luckily, this is a one-time procedure."; ObjectID = "UAW-0G-N5G"; */
+"UAW-0G-N5G.text" = "Le remplissage automatique ne peut pas accéder automatiquement aux fichiers que vous avez déjà dans l'application principale KeePassium.\n\nPourquoi? Derrière les scènes, le système traite le remplissage automatique comme une application séparée, indépendante du processus KeePassium principal. Pour des raisons de sécurité, une application ne peut pas simplement accéder à des fichiers externes, à moins que vous ne liez explicitement ces fichiers à cette application. Ainsi, le système garantit que l'application ne peut accéder qu'aux quelques fichiers que vous avez autorisés.\n\nEn conséquence, le remplissage automatique et l'application principale KeePassium doivent avoir leurs propres permissions pour chaque fichier externe. Heureusement, il s'agit d'une procédure unique.";
+

--- a/KeePassium AutoFill/controllers/fr.lproj/KeyFileChooserVC.strings
+++ b/KeePassium AutoFill/controllers/fr.lproj/KeyFileChooserVC.strings
@@ -1,0 +1,15 @@
+/* Class = "UILabel"; text = "No Key File"; ObjectID = "9UZ-FK-v73"; */
+"9UZ-FK-v73.text" = "Aucun fichier-clé";
+
+/* Class = "UILabel"; text = "Use only password"; ObjectID = "leO-vH-qBX"; */
+"leO-vH-qBX.text" = "Utiliser uniquement le mot de passe";
+
+/* Class = "UIBarButtonItem"; title = "Add Key File"; ObjectID = "Lod-RE-tcd"; */
+"Lod-RE-tcd.title" = "Ajouter un fichier clé";
+
+/* Class = "UIButton"; normalTitle = "Add Key File"; ObjectID = "Omh-Sn-jl2"; */
+"Omh-Sn-jl2.normalTitle" = "Ajouter un fichier clé";
+
+/* Class = "UINavigationItem"; title = "Key Files"; ObjectID = "r85-yz-wYI"; */
+"r85-yz-wYI.title" = "Fichiers clé";
+

--- a/KeePassium AutoFill/fr.lproj/InfoPlist.strings
+++ b/KeePassium AutoFill/fr.lproj/InfoPlist.strings
@@ -1,0 +1,9 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "Remplissage automatique KeePassium";
+
+/* Bundle name */
+"CFBundleName" = "Remplissage automatique KeePassium";
+
+/* Privacy - Face ID Usage Description */
+"NSFaceIDUsageDescription" = "Utilisez FaceID pour déverrouiller KeePassium";
+

--- a/KeePassium AutoFill/fr.lproj/Localizable.strings
+++ b/KeePassium AutoFill/fr.lproj/Localizable.strings
@@ -1,0 +1,261 @@
+/* Action/button to unlock the App Lock with passcode */
+"[AppLock] Unlock" = "Déverrouiller";
+
+/* Hint/Description why the user is asked to provide their fingerprint. Shown in the standard Touch ID prompt. */
+"[AppLock/Biometric/Hint] Unlock KeePassium" = "Débloquer KeePassium";
+
+/* Action/button to switch from TouchID/FaceID prompt to manual input of the AppLock passcode. */
+"[AppLock/cancelBiometricAuth] Use Passcode" = "Utiliser le code d'accès";
+
+/* Action: change keyboard type to enter alphanumeric passphrases */
+"[AppLock/Passcode/KeyboardType/switchAction] 123→ABC" = "123→ABC";
+
+/* Action: change keyboard type to enter PIN numbers */
+"[AppLock/Passcode/KeyboardType/switchAction] ABC→123" = "ABC →123";
+
+/* Message shown when AutoFill cannot automatically open the main app for upgrading to a premium version. */
+"[AutoFill/Premium/Upgrade/Manual/text] To upgrade, please manually open KeePassium from your home screen." = "Pour mettre à jour, veuillez ouvrir manuellement KeePassium à partir de votre écran d'accueil.";
+
+/* Title of a message related to upgrading to the premium version */
+"[AutoFill/Premium/Upgrade/Manual/title] Premium Upgrade" = "Mise à niveau Premium";
+
+/* Name of biometric authentication method. Trademarked, do not translate unless Apple traslated it to your language. */
+"[BiometricAuthType] Face ID" = "Face ID";
+
+/* Name of biometric authentication method. Trademarked, do not translate unless Apple traslated it to your language. */
+"[BiometricAuthType] Touch ID" = "Touch ID";
+
+/* Warning when trying to add a random file as a database. [fileName: String] */
+"[Database/Add] Selected file \"%@\" does not look like a database." = "Le fichier sélectionné \"%@\" ne semble pas être une base de données.";
+
+/* Action/button to create a new database */
+"[Database/Create/action] Create Database" = "Créer une base de données";
+
+/* Title of a form for creating a database */
+"[Database/Create/title] Create Database" = "Créer une base de données";
+
+/* Title of an error message */
+"[Database/Delete] Failed to delete database file" = "Échec de la suppression du fichier de la base de données";
+
+/* Message to confirm deletion of a database file. (This deletes the file itself) */
+"[Database/Delete/Confirm/text] Delete database file?\n Make sure you have a backup." = "Supprimer le fichier de la base de données?\n Assurez-vous d'avoir une sauvegarde.";
+
+/* Status message: loading a database */
+"[Database/Loading/Status] Loading..." = "Chargement en cours…";
+
+/* Notification after changing database master key */
+"[Database/MasterKey/changed] Master key successfully changed" = "La clé principale a été modifiée avec succès";
+
+/* Action/button */
+"[Database/Open/action] Open Database" = "Ouvrir une base de données";
+
+/* Action/button to close current database (for example, when leaving the root group). NOTE: closing does not necessarily lock the database. */
+"[Database/Opened/action] Close" = "Fermer";
+
+/* Action/button to lock current database (the next time, it will ask for the master key). */
+"[Database/Opened/action] Lock Database" = "Verrouiller la base de données";
+
+/* Message to confirm removal of database file from the app. (This keeps the file, but removes its reference from the app.) */
+"[Database/Remove/Confirm/text] Remove database from the list?\n The file will remain intact and you can add it again later." = "Retirer la base de données de la liste ?\n Le fichier restera intact et vous pourrez l'ajouter plus tard.";
+
+/* Status message: finished saving a database */
+"[Database/Saving/Status] Done" = "Fait";
+
+/* Status message: saving a database */
+"[Database/Saving/Status] Saving..." = "Sauvegarde...";
+
+/* Error message related to key file. [errorDetails: String] */
+"[Database/Unlock] Key file error: %@" = "Erreur de fichier de clé: %@";
+
+/* Notification/confirmation message */
+"[Diagnostics] Diagnostic log has been copied to clipboard." = "Le journal de diagnostic a été copié dans le presse-papiers.";
+
+/* Action/button to show internal diagnostic log */
+"[Diagnostics] Show Diagnostic Log" = "Afficher les journaux de diagnostic";
+
+/* Title of a list with attached files */
+"[Entry/Attachments/title] Attached Files" = "Fichiers joints";
+
+/* Action/button to create a new entry in the current group */
+"[Entry/Create/action] Create Entry" = "Créer une entrée";
+
+/* Default name of a newly created entry field */
+"[Entry/Edit/CreateField/defaultName] Field Name" = "Nom du champ";
+
+/* Name of an entry field */
+"[Entry/Field/name] Notes" = "Remarques";
+
+/* Name of an entry field */
+"[Entry/Field/name] Password" = "Mot de passe";
+
+/* Name of an entry field */
+"[Entry/Field/name] Title" = "Titre";
+
+/* Name of an entry field */
+"[Entry/Field/name] URL" = "URL";
+
+/* Name of an entry field */
+"[Entry/Field/name] User Name" = "Nom d'utilisateur";
+
+/* Default title of a new entry */
+"[Entry/New/defaultTitle] New Entry" = "Nouvelle entrée";
+
+/* A suggestion shown after specific file errors (either databases or key files). */
+"[File/PermissionDenied] Try to remove the file from the app, then add it again." = "Essayez de supprimer le fichier de l'application, puis ajoutez-le à nouveau.";
+
+/* Field title */
+"[FileInfo/Field/title] Creation Date" = "Date de création";
+
+/* Field title */
+"[FileInfo/Field/title] File Location" = "Emplacement du fichier";
+
+/* Field title */
+"[FileInfo/Field/title] File Name" = "Nom du fichier";
+
+/* Field title */
+"[FileInfo/Field/title] File Size" = "Taille Du Fichier";
+
+/* Field title */
+"[FileInfo/Field/title] Last Modification Date" = "Date de dernière modification";
+
+/* Title of a field with an error message */
+"[FileInfo/Field/valueError] Error" = "Erreur";
+
+/* Action/button to cancel whatever is going on */
+"[Generic] Cancel" = "Annuler";
+
+/* Action/button to write an email to support */
+"[Generic] Contact Us" = "Contactez-nous";
+
+/* Action/button to move an item (to another group/folder/etc) */
+"[Generic] Copy" = "Copier";
+
+/* Action/button to delete an item (destroys the item/file) */
+"[Generic] Delete" = "Supprimer";
+
+/* Action/button to discard any unsaved changes */
+"[Generic] Discard" = "Annuler";
+
+/* Action/button to close an error message. */
+"[Generic] Dismiss" = "Ignorer";
+
+/* Action/button to finish (editing) and keep changes */
+"[Generic] Done" = "Fait";
+
+/* Action/button to edit an item */
+"[Generic] Edit" = "Éditer";
+
+/* Action/button to export an item to another app */
+"[Generic] Export" = "Exporter";
+
+/* Action/button to move an item (to another group/folder/etc) */
+"[Generic] Move" = "Déplacer";
+
+/* Action/button: generic OK */
+"[Generic] OK" = "OK";
+
+/* Action/button to rename an item */
+"[Generic] Rename" = "Renommer";
+
+/* Action/button to replace an item with another one */
+"[Generic] Replace" = "Remplacer";
+
+/* Action/button to show additional information about an error or item */
+"[Generic] Show Details" = "Voir les détails";
+
+/* Message to confirm deletion of an item. */
+"[Generic/ConfirmDelete/title] Are you sure?" = "Êtes-vous certain ?";
+
+/* Notification text when the user tries to close a document with unsaved changes */
+"[Generic/Edit/Aborting/text] Discard unsaved changes?" = "Annuler les modifications non enregistrées ?";
+
+/* Title of a notification when the user tries to close a document with unsaved changes */
+"[Generic/Edit/Aborting/title] There are unsaved changes" = "Il y a des modifications non enregistrées";
+
+/* Action/button to delete a file (destroys the file forever) */
+"[Generic/File] Delete" = "Supprimer";
+
+/* Action/button to remove a file from the app (the file remains, but the app forgets about it) */
+"[Generic/File] Remove" = "Dissocier";
+
+/* Title of an error message about file export */
+"[Generic/File/title] Export Error" = "Erreur d'exportation";
+
+/* Title of an error message about file import */
+"[Generic/File/title] Import Error" = "Erreur d'importation";
+
+/* Title of an error message notification */
+"[Generic/title] Error" = "Erreur";
+
+/* Title of an error message about iOS system keychain */
+"[Generic/title] Keychain Error" = "Erreur du trousseau";
+
+/* Title of an warning message */
+"[Generic/title] Warning" = "Avertissement";
+
+/* Action/button to create a new sub-group in the current group */
+"[Group/Create/action] Create Group" = "Créer un groupe";
+
+/* Title of a form for creating a group */
+"[Group/Create/title] Create Group" = "Créer un groupe";
+
+/* Title of a form for editing a group */
+"[Group/Edit/title] Edit Group" = "Modifier le Groupe";
+
+/* Default name of a new group */
+"[Group/New/defaultName] New Group" = "Nouveau groupe";
+
+/* Message to confirm deletion of a key file. */
+"[KeyFile/Delete/Confirm/text] Delete key file?\n Make sure you have a backup." = "Supprimer le fichier clé?\n Assurez-vous d'avoir une sauvegarde.";
+
+/* Title of an announcement about the Pro version */
+"[News/2019/10/ProVersionReleaseNews/title] KeePassium Pro" = "KeePassium Pro";
+
+/* Message shown when opening an announcement in AutoFill */
+"[News/AutoFill/stubText] Please open the main app for the full announcement." = "Veuillez ouvrir l'application principale pour l'annonce complète.";
+
+/* Action/button to start choosing premium versions and possibly buying one */
+"[Premium/Upgrade/action] Upgrade to Premium" = "Passer à la version Premium";
+
+/* Description/advertisement for the `Biometric Unlock` premium feature */
+"[PremiumFeature/BiometricAppLock/description] Quickly access your passwords using Face ID/Touch ID in the premium version." = "Accédez rapidement à vos mots de passe en utilisant Face ID/Touch ID dans la version Premium.";
+
+/* Title of a premium feature: ability to use Touch ID / Face ID in AppLock settings (In Title Case) */
+"[PremiumFeature/BiometricAppLock/title] Biometric Unlock" = "Déverrouillage biométrique";
+
+/* Description/advertisement for the `Long Database Timeouts` premium feature */
+"[PremiumFeature/LongDBTimeouts/description] Save time entering your complex master passwords — keep your database open longer in the premium version." = "Gagnez du temps en entrant vos mots de passe principaux complexes — gardez votre base de données ouverte plus longtemps dans la version premium.";
+
+/* Title of a premium feature: ability to set long delays in Database Lock Timeout settings (In Title Case) */
+"[PremiumFeature/LongDBTimeouts/title] Long Database Timeouts" = "Délai d'attente long de la base de données";
+
+/* Description/advertisement for the `Multiple Databases` premium feature */
+"[PremiumFeature/MultiDB/description] Easily switch between databases in the premium version." = "Basculer facilement entre les bases de données dans la version premium.";
+
+/* Title of a premium feature: ability to use multiple databases (In Title Case) */
+"[PremiumFeature/MultiDB/title] Multiple Databases" = "Bases de données multiples";
+
+/* Description/advertisement for the `Preview Attachments` premium feature */
+"[PremiumFeature/Preview/description] Preview images and documents directly in the app, in the premium version." = "Aperçu des images et des documents directement dans l'application, dans la version premium.";
+
+/* Title of a premium feature: ability to preview some attached files directly in the app (In Title Case) */
+"[PremiumFeature/Preview/title] Preview Attachments" = "Aperçu des pièces jointes";
+
+/* Action/button to make password visible as plain-text */
+"[ProtectedTextField] Show Password" = "Afficher le mot de passe";
+
+/* Template text of a bug report email */
+"[Support/template] (Please describe the problem here)" = "(Veuillez décrire le problème ici)";
+
+/* Action/button to add database to the app */
+"Add Database" = "Ajouter une base de données";
+
+/* Title of a window where the user selects a file to be opened/added to the app */
+"Choose Database" = "Choisir la base de données";
+
+/* Action/button */
+"Import Database" = "Importer une base de données";
+
+/* Warning message when the user tries to use a database as a key file */
+"KeePass database should not be used as key file. Please pick a different file." = "La base de données KeePass ne doit pas être utilisée comme fichier clé. Veuillez choisir un autre fichier.";
+

--- a/KeePassium.xcodeproj/project.pbxproj
+++ b/KeePassium.xcodeproj/project.pbxproj
@@ -632,6 +632,50 @@
 		75679ACA22F8095F00372301 /* AppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfo.swift; sourceTree = "<group>"; };
 		75679ACD22FD896F00372301 /* NewsCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsCenter.swift; sourceTree = "<group>"; };
 		756AE9D220CF8B5E00995846 /* ChooseIconVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseIconVC.swift; sourceTree = "<group>"; };
+		756B2433243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		756B2434243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		756B2435243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/FileInfoVC.strings; sourceTree = "<group>"; };
+		756B2436243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		756B2437243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ChangeMasterKeyVC.strings; sourceTree = "<group>"; };
+		756B2438243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/KeyFileChooserVC.strings; sourceTree = "<group>"; };
+		756B2439243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		756B243A243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewEntryFieldsVC.strings; sourceTree = "<group>"; };
+		756B243B243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/CrashReportVC.strings; sourceTree = "<group>"; };
+		756B243C243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/EditEntryVC.strings; sourceTree = "<group>"; };
+		756B243D243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsAppLockVC.strings; sourceTree = "<group>"; };
+		756B243E243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsBackupVC.strings; sourceTree = "<group>"; };
+		756B243F243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ChooseDatabaseVC.strings; sourceTree = "<group>"; };
+		756B2440243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ChooseIconVC.strings; sourceTree = "<group>"; };
+		756B2441243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsFileSortingVC.strings; sourceTree = "<group>"; };
+		756B2442243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsDataProtectionVC.strings; sourceTree = "<group>"; };
+		756B2443243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/EditGroupVC.strings; sourceTree = "<group>"; };
+		756B2444243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/UnlockDatabaseVC.strings; sourceTree = "<group>"; };
+		756B2445243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewEntryVC.strings; sourceTree = "<group>"; };
+		756B2446243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/DiagnosticsViewerVC.strings; sourceTree = "<group>"; };
+		756B2447243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsDatabaseTimeoutVC.strings; sourceTree = "<group>"; };
+		756B2448243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/EntryFinderVC.strings; sourceTree = "<group>"; };
+		756B2449243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewGroupVC.strings; sourceTree = "<group>"; };
+		756B244A243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsItemListVC.strings; sourceTree = "<group>"; };
+		756B244B243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ChooseKeyFileVC.strings; sourceTree = "<group>"; };
+		756B244C243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsAppTimeoutVC.strings; sourceTree = "<group>"; };
+		756B244D243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/DatabaseChooserVC.strings; sourceTree = "<group>"; };
+		756B244E243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsAutoFillVC.strings; sourceTree = "<group>"; };
+		756B244F243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/AboutVC.strings; sourceTree = "<group>"; };
+		756B2450243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewEntryFilesVC.strings; sourceTree = "<group>"; };
+		756B2451243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/FirstSetupVC.strings; sourceTree = "<group>"; };
+		756B2452243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewEntryHistoryVC.strings; sourceTree = "<group>"; };
+		756B2453243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/ViewDiagnosticsVC.strings; sourceTree = "<group>"; };
+		756B2454243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PremiumContainerVC.strings; sourceTree = "<group>"; };
+		756B2455243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/WelcomeVC.strings; sourceTree = "<group>"; };
+		756B2456243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/DatabaseCreatorVC.strings; sourceTree = "<group>"; };
+		756B2457243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PremiumVC.strings; sourceTree = "<group>"; };
+		756B2458243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsVC.strings; sourceTree = "<group>"; };
+		756B2459243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/DatabaseUnlockerVC.strings; sourceTree = "<group>"; };
+		756B245A243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PremiumProVC.strings; sourceTree = "<group>"; };
+		756B245B243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsClipboardTimeoutVC.strings; sourceTree = "<group>"; };
+		756B245C243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PasswordGeneratorVC.strings; sourceTree = "<group>"; };
+		756B245D243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/PasscodeInputVC.strings; sourceTree = "<group>"; };
+		756B245E243F74E000AA121A /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/SettingsBackupTimeoutPickerVC.strings; sourceTree = "<group>"; };
 		756C4CA52349DFE0003F7E52 /* _201910_ProVersionReleaseNews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _201910_ProVersionReleaseNews.swift; sourceTree = "<group>"; };
 		756C4CBC234A41E4003F7E52 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/PremiumProVC.strings; sourceTree = "<group>"; };
 		756C4CBE234A41E7003F7E52 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/PremiumProVC.strings; sourceTree = "<group>"; };
@@ -1623,6 +1667,7 @@
 				cs,
 				sv,
 				es,
+				fr,
 			);
 			mainGroup = 754BF0722082A6BD00E3A292;
 			productRefGroup = 754BF07C2082A6BD00E3A292 /* Products */;
@@ -2200,6 +2245,7 @@
 				75FDEF2D233ABE9A00F17C26 /* cs */,
 				75FDEF55233ABEEC00F17C26 /* sv */,
 				75AC35C723549DE700B60614 /* es */,
+				756B2442243F74E000AA121A /* fr */,
 			);
 			name = SettingsDataProtectionVC.storyboard;
 			sourceTree = "<group>";
@@ -2216,6 +2262,7 @@
 				75FDEF2C233ABE9A00F17C26 /* cs */,
 				75FDEF58233ABEEC00F17C26 /* sv */,
 				75AC35CA23549DE700B60614 /* es */,
+				756B2441243F74E000AA121A /* fr */,
 			);
 			name = SettingsFileSortingVC.storyboard;
 			sourceTree = "<group>";
@@ -2232,6 +2279,7 @@
 				75FDEF43233ABE9A00F17C26 /* cs */,
 				75FDEF6F233ABEEC00F17C26 /* sv */,
 				75AC35E123549DE700B60614 /* es */,
+				756B2458243F74E000AA121A /* fr */,
 			);
 			name = SettingsVC.storyboard;
 			sourceTree = "<group>";
@@ -2248,6 +2296,7 @@
 				75FDEF29233ABE9A00F17C26 /* cs */,
 				75FDEF59233ABEEC00F17C26 /* sv */,
 				75AC35CB23549DE700B60614 /* es */,
+				756B243E243F74E000AA121A /* fr */,
 			);
 			name = SettingsBackupVC.storyboard;
 			sourceTree = "<group>";
@@ -2264,6 +2313,7 @@
 				75FDEF28233ABE9A00F17C26 /* cs */,
 				75FDEF54233ABEEC00F17C26 /* sv */,
 				75AC35C623549DE700B60614 /* es */,
+				756B243D243F74E000AA121A /* fr */,
 			);
 			name = SettingsAppLockVC.storyboard;
 			sourceTree = "<group>";
@@ -2280,6 +2330,7 @@
 				75FDEF3B233ABE9A00F17C26 /* cs */,
 				75FDEF66233ABEEC00F17C26 /* sv */,
 				75AC35D723549DE700B60614 /* es */,
+				756B244E243F74E000AA121A /* fr */,
 			);
 			name = SettingsAutoFillVC.storyboard;
 			sourceTree = "<group>";
@@ -2296,6 +2347,7 @@
 				75FDEF42233ABE9A00F17C26 /* cs */,
 				75FDEF6E233ABEEC00F17C26 /* sv */,
 				75AC35E023549DE700B60614 /* es */,
+				756B2457243F74E000AA121A /* fr */,
 			);
 			name = PremiumVC.storyboard;
 			sourceTree = "<group>";
@@ -2312,6 +2364,7 @@
 				75FDEF35233ABE9A00F17C26 /* cs */,
 				75FDEF61233ABEEC00F17C26 /* sv */,
 				75AC35D123549DE700B60614 /* es */,
+				756B2449243F74E000AA121A /* fr */,
 			);
 			name = ViewGroupVC.storyboard;
 			sourceTree = "<group>";
@@ -2328,6 +2381,7 @@
 				75FDEF2E233ABE9A00F17C26 /* cs */,
 				75FDEF5A233ABEEC00F17C26 /* sv */,
 				75AC35CC23549DE700B60614 /* es */,
+				756B2443243F74E000AA121A /* fr */,
 			);
 			name = EditGroupVC.storyboard;
 			sourceTree = "<group>";
@@ -2344,6 +2398,7 @@
 				75FDEF27233ABE9A00F17C26 /* cs */,
 				75FDEF53233ABEEC00F17C26 /* sv */,
 				75AC35C523549DE700B60614 /* es */,
+				756B243C243F74E000AA121A /* fr */,
 			);
 			name = EditEntryVC.storyboard;
 			sourceTree = "<group>";
@@ -2360,6 +2415,7 @@
 				75FDEF46233ABE9A00F17C26 /* cs */,
 				75FDEF72233ABEEC00F17C26 /* sv */,
 				75AC35E523549DE700B60614 /* es */,
+				756B245C243F74E000AA121A /* fr */,
 			);
 			name = PasswordGeneratorVC.storyboard;
 			sourceTree = "<group>";
@@ -2376,6 +2432,7 @@
 				75FDEF30233ABE9A00F17C26 /* cs */,
 				75FDEF5C233ABEEC00F17C26 /* sv */,
 				75AC35CE23549DE700B60614 /* es */,
+				756B2445243F74E000AA121A /* fr */,
 			);
 			name = ViewEntryVC.storyboard;
 			sourceTree = "<group>";
@@ -2392,6 +2449,7 @@
 				75FDEF25233ABE9A00F17C26 /* cs */,
 				75FDEF51233ABEEC00F17C26 /* sv */,
 				75AC35C323549DE700B60614 /* es */,
+				756B243A243F74E000AA121A /* fr */,
 			);
 			name = ViewEntryFieldsVC.storyboard;
 			sourceTree = "<group>";
@@ -2408,6 +2466,7 @@
 				75FDEF3C233ABE9A00F17C26 /* cs */,
 				75FDEF68233ABEEC00F17C26 /* sv */,
 				75AC35D923549DE700B60614 /* es */,
+				756B2450243F74E000AA121A /* fr */,
 			);
 			name = ViewEntryFilesVC.storyboard;
 			sourceTree = "<group>";
@@ -2424,6 +2483,7 @@
 				75FDEF3E233ABE9A00F17C26 /* cs */,
 				75FDEF6A233ABEEC00F17C26 /* sv */,
 				75AC35DB23549DE700B60614 /* es */,
+				756B2452243F74E000AA121A /* fr */,
 			);
 			name = ViewEntryHistoryVC.storyboard;
 			sourceTree = "<group>";
@@ -2440,6 +2500,7 @@
 				75FDEF2A233ABE9A00F17C26 /* cs */,
 				75FDEF56233ABEEC00F17C26 /* sv */,
 				75AC35C823549DE700B60614 /* es */,
+				756B243F243F74E000AA121A /* fr */,
 			);
 			name = ChooseDatabaseVC.storyboard;
 			sourceTree = "<group>";
@@ -2456,6 +2517,7 @@
 				75FDEF37233ABE9A00F17C26 /* cs */,
 				75FDEF63233ABEEC00F17C26 /* sv */,
 				75AC35D423549DE700B60614 /* es */,
+				756B244B243F74E000AA121A /* fr */,
 			);
 			name = ChooseKeyFileVC.storyboard;
 			sourceTree = "<group>";
@@ -2472,6 +2534,7 @@
 				75FDEF22233ABE9A00F17C26 /* cs */,
 				75FDEF4E233ABEEC00F17C26 /* sv */,
 				75AC35BE23549DE700B60614 /* es */,
+				756B2437243F74E000AA121A /* fr */,
 			);
 			name = ChangeMasterKeyVC.storyboard;
 			sourceTree = "<group>";
@@ -2488,6 +2551,7 @@
 				75FDEF2F233ABE9A00F17C26 /* cs */,
 				75FDEF5B233ABEEC00F17C26 /* sv */,
 				75AC35CD23549DE700B60614 /* es */,
+				756B2444243F74E000AA121A /* fr */,
 			);
 			name = UnlockDatabaseVC.storyboard;
 			sourceTree = "<group>";
@@ -2504,6 +2568,7 @@
 				75FDEF41233ABE9A00F17C26 /* cs */,
 				75FDEF6D233ABEEC00F17C26 /* sv */,
 				75AC35DF23549DE700B60614 /* es */,
+				756B2456243F74E000AA121A /* fr */,
 			);
 			name = DatabaseCreatorVC.storyboard;
 			sourceTree = "<group>";
@@ -2520,6 +2585,7 @@
 				75FDEF2B233ABE9A00F17C26 /* cs */,
 				75FDEF57233ABEEC00F17C26 /* sv */,
 				75AC35C923549DE700B60614 /* es */,
+				756B2440243F74E000AA121A /* fr */,
 			);
 			name = ChooseIconVC.storyboard;
 			sourceTree = "<group>";
@@ -2536,6 +2602,7 @@
 				75FDEF20233ABE9A00F17C26 /* cs */,
 				75FDEF4C233ABEEC00F17C26 /* sv */,
 				75AC35E723549DE700B60614 /* es */,
+				756B2435243F74E000AA121A /* fr */,
 			);
 			name = FileInfoVC.storyboard;
 			sourceTree = "<group>";
@@ -2552,6 +2619,7 @@
 				75FDEF26233ABE9A00F17C26 /* cs */,
 				75FDEF52233ABEEC00F17C26 /* sv */,
 				75AC35C423549DE700B60614 /* es */,
+				756B243B243F74E000AA121A /* fr */,
 			);
 			name = CrashReportVC.storyboard;
 			sourceTree = "<group>";
@@ -2568,6 +2636,7 @@
 				75FDEF3D233ABE9A00F17C26 /* cs */,
 				75FDEF69233ABEEC00F17C26 /* sv */,
 				75AC35DA23549DE700B60614 /* es */,
+				756B2451243F74E000AA121A /* fr */,
 			);
 			name = FirstSetupVC.storyboard;
 			sourceTree = "<group>";
@@ -2584,6 +2653,7 @@
 				75FDEF3A233ABE9A00F17C26 /* cs */,
 				75FDEF65233ABEEC00F17C26 /* sv */,
 				75AC35D623549DE700B60614 /* es */,
+				756B244D243F74E000AA121A /* fr */,
 			);
 			name = DatabaseChooserVC.storyboard;
 			sourceTree = "<group>";
@@ -2600,6 +2670,7 @@
 				75FDEF44233ABE9A00F17C26 /* cs */,
 				75FDEF70233ABEEC00F17C26 /* sv */,
 				75AC35E223549DE700B60614 /* es */,
+				756B2459243F74E000AA121A /* fr */,
 			);
 			name = DatabaseUnlockerVC.storyboard;
 			sourceTree = "<group>";
@@ -2616,6 +2687,7 @@
 				75FDEF34233ABE9A00F17C26 /* cs */,
 				75FDEF60233ABEEC00F17C26 /* sv */,
 				75AC35D223549DE700B60614 /* es */,
+				756B2448243F74E000AA121A /* fr */,
 			);
 			name = EntryFinderVC.storyboard;
 			sourceTree = "<group>";
@@ -2632,6 +2704,7 @@
 				75FDEF24233ABE9A00F17C26 /* cs */,
 				75FDEF50233ABEEC00F17C26 /* sv */,
 				75AC35C023549DE700B60614 /* es */,
+				756B2438243F74E000AA121A /* fr */,
 			);
 			name = KeyFileChooserVC.storyboard;
 			sourceTree = "<group>";
@@ -2648,6 +2721,7 @@
 				75FDEF31233ABE9A00F17C26 /* cs */,
 				75FDEF5D233ABEEC00F17C26 /* sv */,
 				75AC35CF23549DE700B60614 /* es */,
+				756B2446243F74E000AA121A /* fr */,
 			);
 			name = DiagnosticsViewerVC.storyboard;
 			sourceTree = "<group>";
@@ -2672,6 +2746,7 @@
 				756C4CC6234A41F6003F7E52 /* zh-Hans */,
 				756C4CC8234A41F8003F7E52 /* zh-Hant */,
 				75AC35E323549DE700B60614 /* es */,
+				756B245A243F74E000AA121A /* fr */,
 			);
 			name = PremiumProVC.storyboard;
 			sourceTree = "<group>";
@@ -2704,6 +2779,7 @@
 				75FDEF39233ABE9A00F17C26 /* cs */,
 				75FDEF67233ABEEC00F17C26 /* sv */,
 				75AC35D823549DE700B60614 /* es */,
+				756B244F243F74E000AA121A /* fr */,
 			);
 			name = AboutVC.storyboard;
 			sourceTree = "<group>";
@@ -2720,6 +2796,7 @@
 				75FDEF47233ABE9A00F17C26 /* cs */,
 				75FDEF73233ABEEC00F17C26 /* sv */,
 				75AC35E623549DE700B60614 /* es */,
+				756B245D243F74E000AA121A /* fr */,
 			);
 			name = PasscodeInputVC.storyboard;
 			sourceTree = "<group>";
@@ -2736,6 +2813,7 @@
 				75FDEF3F233ABE9A00F17C26 /* cs */,
 				75FDEF6B233ABEEC00F17C26 /* sv */,
 				75AC35DC23549DE700B60614 /* es */,
+				756B2453243F74E000AA121A /* fr */,
 			);
 			name = ViewDiagnosticsVC.storyboard;
 			sourceTree = "<group>";
@@ -2752,6 +2830,7 @@
 				75FDEF40233ABE9A00F17C26 /* cs */,
 				75FDEF6C233ABEEC00F17C26 /* sv */,
 				75AC35DE23549DE700B60614 /* es */,
+				756B2455243F74E000AA121A /* fr */,
 			);
 			name = WelcomeVC.storyboard;
 			sourceTree = "<group>";
@@ -2767,6 +2846,7 @@
 				75FDEF1E233ABE9A00F17C26 /* cs */,
 				75FDEF4A233ABEEC00F17C26 /* sv */,
 				75AC35BC23549DE700B60614 /* es */,
+				756B2433243F74E000AA121A /* fr */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -2782,6 +2862,7 @@
 				75FDEF1F233ABE9A00F17C26 /* cs */,
 				75FDEF4B233ABEEC00F17C26 /* sv */,
 				75AC35BD23549DE700B60614 /* es */,
+				756B2434243F74E000AA121A /* fr */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -2797,6 +2878,7 @@
 				75FDEF21233ABE9A00F17C26 /* cs */,
 				75FDEF4D233ABEEC00F17C26 /* sv */,
 				75AC35BF23549DE700B60614 /* es */,
+				756B2436243F74E000AA121A /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2812,6 +2894,7 @@
 				75FDEF23233ABE9A00F17C26 /* cs */,
 				75FDEF4F233ABEEC00F17C26 /* sv */,
 				75AC35C223549DE700B60614 /* es */,
+				756B2439243F74E000AA121A /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2828,6 +2911,7 @@
 				756C4CD8234A49D9003F7E52 /* ru */,
 				756C4CDA234A49DA003F7E52 /* sv */,
 				75AC35DD23549DE700B60614 /* es */,
+				756B2454243F74E000AA121A /* fr */,
 			);
 			name = PremiumContainerVC.storyboard;
 			sourceTree = "<group>";
@@ -2844,6 +2928,7 @@
 				75FDEF38233ABE9A00F17C26 /* cs */,
 				75FDEF64233ABEEC00F17C26 /* sv */,
 				75AC35D523549DE700B60614 /* es */,
+				756B244C243F74E000AA121A /* fr */,
 			);
 			name = SettingsAppTimeoutVC.storyboard;
 			sourceTree = "<group>";
@@ -2860,6 +2945,7 @@
 				75FDEF48233ABE9A00F17C26 /* cs */,
 				75FDEF74233ABEEC00F17C26 /* sv */,
 				75AC35C123549DE700B60614 /* es */,
+				756B245E243F74E000AA121A /* fr */,
 			);
 			name = SettingsBackupTimeoutPickerVC.storyboard;
 			sourceTree = "<group>";
@@ -2876,6 +2962,7 @@
 				75FDEF33233ABE9A00F17C26 /* cs */,
 				75FDEF5F233ABEEC00F17C26 /* sv */,
 				75AC35D023549DE700B60614 /* es */,
+				756B2447243F74E000AA121A /* fr */,
 			);
 			name = SettingsDatabaseTimeoutVC.storyboard;
 			sourceTree = "<group>";
@@ -2892,6 +2979,7 @@
 				75FDEF45233ABE9A00F17C26 /* cs */,
 				75FDEF71233ABEEC00F17C26 /* sv */,
 				75AC35E423549DE700B60614 /* es */,
+				756B245B243F74E000AA121A /* fr */,
 			);
 			name = SettingsClipboardTimeoutVC.storyboard;
 			sourceTree = "<group>";
@@ -2908,6 +2996,7 @@
 				75FDEF36233ABE9A00F17C26 /* cs */,
 				75FDEF62233ABEEC00F17C26 /* sv */,
 				75AC35D323549DE700B60614 /* es */,
+				756B244A243F74E000AA121A /* fr */,
 			);
 			name = SettingsItemListVC.storyboard;
 			sourceTree = "<group>";
@@ -2921,12 +3010,12 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "KeePassium AutoFill/KeePassium_AutoFill.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				INFOPLIST_FILE = "KeePassium AutoFill/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -2945,12 +3034,12 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "KeePassium AutoFill/KeePassium_AutoFill.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				INFOPLIST_FILE = "KeePassium AutoFill/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keepassium.ios.KeePassium-AutoFill";
@@ -3090,7 +3179,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon";
 				CODE_SIGN_ENTITLEMENTS = KeePassium/KeePassium.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -3099,7 +3188,7 @@
 				INFOPLIST_FILE = KeePassium/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keepassium.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3117,7 +3206,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon";
 				CODE_SIGN_ENTITLEMENTS = KeePassium/KeePassium.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -3126,7 +3215,7 @@
 				INFOPLIST_FILE = KeePassium/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keepassium.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3144,7 +3233,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-pro";
 				CODE_SIGN_ENTITLEMENTS = KeePassium/KeePassium.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -3153,7 +3242,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/KeePassium/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keepassium.ios.pro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3171,7 +3260,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "app-icon-pro";
 				CODE_SIGN_ENTITLEMENTS = KeePassium/KeePassium.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_OPTIMIZATION_LEVEL = fast;
@@ -3180,7 +3269,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/KeePassium/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.keepassium.ios.pro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3197,12 +3286,12 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "KeePassium AutoFill/KeePassium_AutoFill.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				INFOPLIST_FILE = "$(SRCROOT)/KeePassium AutoFill/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
@@ -3221,12 +3310,12 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = "KeePassium AutoFill/KeePassium_AutoFill.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 53;
+				CURRENT_PROJECT_VERSION = 54;
 				DEVELOPMENT_TEAM = 84W4PHXS24;
 				INFOPLIST_FILE = "$(SRCROOT)/KeePassium AutoFill/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				MARKETING_VERSION = 1.10;
+				MARKETING_VERSION = 1.11;
 				MTL_FAST_MATH = YES;
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.keepassium.ios.pro.KeePassium-AutoFill";

--- a/KeePassium.xcworkspace/contents.xcworkspacedata
+++ b/KeePassium.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/andrei/Dropbox/Projects/XCode/KeePassium/KeePassiumLib/KeePassiumLib.xcodeproj">
+      location = "group:KeePassiumLib/KeePassiumLib.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:YubiKit/YubiKit.xcodeproj">

--- a/KeePassium/AppDelegate.swift
+++ b/KeePassium/AppDelegate.swift
@@ -56,6 +56,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        let rootVC = window?.rootViewController as? FileKeeperDelegate
+        assert(rootVC != nil, "FileKeeper needs a delegate")
+        FileKeeper.shared.delegate = rootVC
+    }
+    
     func applicationWillTerminate(_ application: UIApplication) {
         PremiumManager.shared.finishObservingTransactions()
     }

--- a/KeePassium/cs.lproj/Localizable.strings
+++ b/KeePassium/cs.lproj/Localizable.strings
@@ -188,7 +188,7 @@
 "[FileInfo/Field/valueError] Error" = "Chyba";
 
 /* Title of the dialog for picking the destination group for move/copy operations */
-"[General/DestinationGroup/title] Choose a Destination" = "Choose a Destination";
+"[General/DestinationGroup/title] Choose a Destination" = "Vyberte cíl";
 
 /* Action/button to cancel whatever is going on */
 "[Generic] Cancel" = "Zrušit";

--- a/KeePassium/database/ChooseDatabaseVC.swift
+++ b/KeePassium/database/ChooseDatabaseVC.swift
@@ -228,7 +228,8 @@ class ChooseDatabaseVC: UITableViewController, Refreshable {
     }
 
     @IBAction func didPressAddDatabase(_ sender: Any) {
-        if databaseRefs.count > 0 {
+        let nonBackupDatabaseRefs = databaseRefs.filter { $0.location != .internalBackup }
+        if nonBackupDatabaseRefs.count > 0 {
             premiumUpgradeHelper.performActionOrOfferUpgrade(.canUseMultipleDatabases, in: self) {
                 [weak self] in
                 self?.handleDidPressAddDatabase()

--- a/KeePassium/database/de.lproj/ChooseDatabaseVC.strings
+++ b/KeePassium/database/de.lproj/ChooseDatabaseVC.strings
@@ -2,7 +2,7 @@
 "2o3-sG-Pcm.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Hilfe";
 
 /* Class = "UILabel"; text = "No database files"; ObjectID = "5Md-DB-C5P"; Note = "Placeholder shown when there are no database files available"; */
-"5Md-DB-C5P.text" = "keine Datenbank";
+"5Md-DB-C5P.text" = "Keine Datenbank";
 
 /* Class = "UIBarButtonItem"; lnO-nD-gvh.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Sort Order"; ObjectID = "lnO-nD-gvh"; Note = "Action: show sorting settings of database files"; */
 "lnO-nD-gvh.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Sortieren nach";

--- a/KeePassium/database/entry/ViewEntryFieldCells.swift
+++ b/KeePassium/database/entry/ViewEntryFieldCells.swift
@@ -24,7 +24,7 @@ class ViewableFieldCellFactory {
         
         if field is TOTPViewableField {
             cell.decorator = TOTPFieldCellDecorator(cell: cell)
-        } else if field.isProtected {
+        } else if field.isProtected || (field.internalName == EntryField.password) {
             cell.decorator = ProtectedFieldCellDecorator(cell: cell)
         } else {
             cell.decorator = URLFieldCellDecorator(cell: cell)
@@ -221,6 +221,7 @@ class ProtectedFieldCellDecorator: ViewableFieldCellDecorator {
                 if cell.field?.isValueHidden ?? true {
                     cell.valueText.attributedText = nil
                     cell.valueText.text = value
+                    cell.valueText.textColor = .primaryText
                 } else {
                     cell.valueText.attributedText = PasswordStringHelper.decorate(
                         value ?? "",

--- a/KeePassium/database/entry/ViewEntryFieldsVC.swift
+++ b/KeePassium/database/entry/ViewEntryFieldsVC.swift
@@ -44,6 +44,7 @@ class ViewEntryFieldsVC: UITableViewController, Refreshable {
         editButton.accessibilityIdentifier = "edit_entry_button" 
 
         entryChangeNotifications = EntryChangeNotifications(observer: self)
+        entry?.touch(.accessed)
         refresh()
     }
 
@@ -118,6 +119,7 @@ class ViewEntryFieldsVC: UITableViewController, Refreshable {
         } else {
             Clipboard.general.insert(text: text, timeout: timeout)
         }
+        entry?.touch(.accessed)
         animateCopyToClipboard(indexPath: indexPath)
     }
     

--- a/KeePassium/database/entry/ViewEntryFilesVC.swift
+++ b/KeePassium/database/entry/ViewEntryFilesVC.swift
@@ -37,6 +37,8 @@ class ViewEntryFilesVC: UITableViewController, Refreshable {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        entry?.touch(.accessed)
+        
         editButton = UIBarButtonItem(
             title: LString.actionEdit,
             style: .plain,
@@ -124,6 +126,7 @@ class ViewEntryFilesVC: UITableViewController, Refreshable {
         
         tableView.deselectRow(at: indexPath, animated: true)
         
+        entry?.touch(.accessed)
         let row = indexPath.row
         if row < attachments.count {
             if tableView.isEditing {
@@ -323,7 +326,6 @@ class ViewEntryFilesVC: UITableViewController, Refreshable {
     private func didPressDeleteAttachment(at indexPath: IndexPath) {
         guard let entry = entry else { return }
         entry.backupState()
-        entry.modified()
         entry.attachments.remove(at: indexPath.row)
         Diag.info("Attachment deleted OK")
         
@@ -348,7 +350,7 @@ class ViewEntryFilesVC: UITableViewController, Refreshable {
     
     private func applyChangesAndSaveDatabase() {
         guard let entry = entry else { return }
-        entry.modified()
+        entry.touch(.modified, updateParents: false)
         DatabaseManager.shared.addObserver(self)
         DatabaseManager.shared.startSavingDatabase()
     }
@@ -436,8 +438,7 @@ extension ViewEntryFilesVC: UIDocumentPickerDelegate {
     private func addAttachment(name: String, data: ByteArray) {
         guard let entry = entry, let database = entry.database else { return }
         entry.backupState()
-        entry.modified()
-
+        
         let newAttachment = database.makeAttachment(name: name, data: data)
         if !entry.isSupportsMultipleAttachments {
             entry.attachments.removeAll()

--- a/KeePassium/database/entry/ViewEntryVC.swift
+++ b/KeePassium/database/entry/ViewEntryVC.swift
@@ -29,6 +29,7 @@ class ViewEntryVC: UIViewController, Refreshable {
         viewEntryVC.entry = entry
         viewEntryVC.isHistoryMode = historyMode
         viewEntryVC.refresh()
+        entry.touch(.accessed)
         if !historyMode {
             let navVC = UINavigationController(rootViewController: viewEntryVC)
             return navVC

--- a/KeePassium/database/entry/edit/EditEntryVC.swift
+++ b/KeePassium/database/entry/edit/EditEntryVC.swift
@@ -98,7 +98,8 @@ class EditEntryVC: UITableViewController, Refreshable {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44.0
         
-        entry?.accessed()
+        entry?.touch(.accessed)
+        
         refresh()
         if mode == .create {
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.8)
@@ -297,7 +298,7 @@ class EditEntryVC: UITableViewController, Refreshable {
     
     func applyChangesAndSaveDatabase() {
         guard let entry = entry else { return }
-        entry.modified()
+        entry.touch(.modified, updateParents: false)
         view.endEditing(true)
         DatabaseManager.shared.addObserver(self)
         DatabaseManager.shared.startSavingDatabase()

--- a/KeePassium/database/entry/edit/de.lproj/PasswordGeneratorVC.strings
+++ b/KeePassium/database/entry/edit/de.lproj/PasswordGeneratorVC.strings
@@ -1,5 +1,5 @@
 /* Class = "UILabel"; text = "Look-Alike Characters (1Il…)"; ObjectID = "5Xu-cN-kSg"; Note = "Symbols to include in generated passwords."; */
-"5Xu-cN-kSg.text" = "ähnlich aussehende Zeichen (1Il…)";
+"5Xu-cN-kSg.text" = "Ähnlich aussehende Zeichen (1Il…)";
 
 /* Class = "UILabel"; text = "Password Length"; ObjectID = "Hxj-CB-VE7"; Note = "Label of the control that specifies the length of the password to be generated"; */
 "Hxj-CB-VE7.text" = "Passwortlänge";

--- a/KeePassium/database/entry/edit/fr.lproj/EditEntryVC.strings
+++ b/KeePassium/database/entry/edit/fr.lproj/EditEntryVC.strings
@@ -1,0 +1,24 @@
+/* Class = "UILabel"; text = "In-memory Protection"; ObjectID = "0pb-xb-fuf"; Note = "Label for a switch, equivalent to KeePass' own `Enable in-memory protection` for custom entry fields."; */
+"0pb-xb-fuf.text" = "Protection en mémoire";
+
+/* Class = "UITableViewCell"; CcF-c8-r4M.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Custom field editor"; ObjectID = "CcF-c8-r4M"; */
+"CcF-c8-r4M.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Éditeur de champ personnalisé";
+
+/* Class = "UISwitch"; eox-My-Hns.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "In-memory Protection"; ObjectID = "eox-My-Hns"; Note = "Equivalent to KeePass' own `Enable in-memory protection' for custom entry fields."; */
+"eox-My-Hns.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Protection en mémoire";
+
+/* Class = "UIButton"; normalTitle = "Change Icon"; ObjectID = "HcW-rc-pdR"; */
+"HcW-rc-pdR.normalTitle" = "Changer l'icône";
+
+/* Class = "UIBarButtonItem"; HGI-xq-zUf.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Add Custom Field"; ObjectID = "HGI-xq-zUf"; */
+"HGI-xq-zUf.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Ajouter un champ personnalisé";
+
+/* Class = "UINavigationItem"; title = "Edit Entry"; ObjectID = "l3s-Bv-fA1"; */
+"l3s-Bv-fA1.title" = "Modifier l'entrée";
+
+/* Class = "UIButton"; z2C-wo-jYf.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Randomize password"; ObjectID = "z2C-wo-jYf"; Note = "Action/button to generate new password"; */
+"z2C-wo-jYf.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Mot de passe aléatoire";
+
+/* Class = "UIButton"; normalTitle = "Randomize"; ObjectID = "z2C-wo-jYf"; Note = "Action/button to generate new password"; */
+"z2C-wo-jYf.normalTitle" = "Aléatoire";
+

--- a/KeePassium/database/entry/edit/fr.lproj/PasswordGeneratorVC.strings
+++ b/KeePassium/database/entry/edit/fr.lproj/PasswordGeneratorVC.strings
@@ -1,0 +1,21 @@
+/* Class = "UILabel"; text = "Look-Alike Characters (1Il…)"; ObjectID = "5Xu-cN-kSg"; Note = "Symbols to include in generated passwords."; */
+"5Xu-cN-kSg.text" = "Caractères ressemblants (1Il…)";
+
+/* Class = "UILabel"; text = "Password Length"; ObjectID = "Hxj-CB-VE7"; Note = "Label of the control that specifies the length of the password to be generated"; */
+"Hxj-CB-VE7.text" = "Longueur du mot de passe";
+
+/* Class = "UILabel"; text = "Digits (123…)"; ObjectID = "iRk-FV-7U8"; Note = "Symbols to include in generated passwords. Don't translate the digits."; */
+"iRk-FV-7U8.text" = "Chiffres (123…)";
+
+/* Class = "UILabel"; text = "Special Symbols (@#$…)"; ObjectID = "Mwu-Lk-3MU"; Note = "Symbols to include in generated passwords."; */
+"Mwu-Lk-3MU.text" = "Symboles spéciaux (@#$…)";
+
+/* Class = "UINavigationItem"; title = "Randomizer"; ObjectID = "O7Z-bK-bJa"; Note = "Title of the password generator screen."; */
+"O7Z-bK-bJa.title" = "Générateur aléatoire";
+
+/* Class = "UILabel"; text = "Lower Case Letters (abc…)"; ObjectID = "Rwu-qh-8ON"; Note = "Symbols to include in generated passwords. Don't translate the letters."; */
+"Rwu-qh-8ON.text" = "Lettres minuscules (abc…)";
+
+/* Class = "UILabel"; text = "Upper Case Letters (ABC…)"; ObjectID = "x93-rB-nNr"; Note = "Symbols to include in generated passwords. Don't translate the letters."; */
+"x93-rB-nNr.text" = "Lettres en majuscule (ABC…)";
+

--- a/KeePassium/database/entry/fr.lproj/ViewEntryFieldsVC.strings
+++ b/KeePassium/database/entry/fr.lproj/ViewEntryFieldsVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UILabel"; text = "Copied"; ObjectID = "vLP-Zc-bUc"; Note = "Confirmation message: field value has been copied to clipboard."; */
+"vLP-Zc-bUc.text" = "Copié";
+

--- a/KeePassium/database/entry/fr.lproj/ViewEntryFilesVC.strings
+++ b/KeePassium/database/entry/fr.lproj/ViewEntryFilesVC.strings
@@ -1,0 +1,6 @@
+/* Class = "UILabel"; text = "Add File"; ObjectID = "bgK-Q6-nzE"; Note = "Action: attach a file to the entry."; */
+"bgK-Q6-nzE.text" = "Ajouter un fichier";
+
+/* Class = "UILabel"; text = "There are no attached files"; ObjectID = "W86-tp-bfF"; Note = "Placeholder shown when there are no attached files in the entry."; */
+"W86-tp-bfF.text" = "Il n'y a aucun fichier joint";
+

--- a/KeePassium/database/entry/fr.lproj/ViewEntryHistoryVC.strings
+++ b/KeePassium/database/entry/fr.lproj/ViewEntryHistoryVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UILabel"; text = "There are no previous versions"; ObjectID = "bzL-mr-Hrz"; Note = "Placeholder text shown when the entry does not have previous versions/revisions (has never been changed)"; */
+"bzL-mr-Hrz.text" = "Il n'y a pas de versions précédentes";
+

--- a/KeePassium/database/entry/fr.lproj/ViewEntryVC.strings
+++ b/KeePassium/database/entry/fr.lproj/ViewEntryVC.strings
@@ -1,0 +1,9 @@
+/* Class = "UISegmentedControl"; g9A-4w-Dsa.segmentTitles[0] = "General"; ObjectID = "g9A-4w-Dsa"; */
+"g9A-4w-Dsa.segmentTitles[0]" = "Général";
+
+/* Class = "UISegmentedControl"; g9A-4w-Dsa.segmentTitles[1] = "Files"; ObjectID = "g9A-4w-Dsa"; */
+"g9A-4w-Dsa.segmentTitles[1]" = "Fichiers";
+
+/* Class = "UISegmentedControl"; g9A-4w-Dsa.segmentTitles[2] = "History"; ObjectID = "g9A-4w-Dsa"; */
+"g9A-4w-Dsa.segmentTitles[2]" = "Historique";
+

--- a/KeePassium/database/fr.lproj/ChangeMasterKeyVC.strings
+++ b/KeePassium/database/fr.lproj/ChangeMasterKeyVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UITextField"; placeholder = "New Password"; ObjectID = "hYP-f0-K1s"; Note = "Placeholder: text field for changing the master password"; */
+"hYP-f0-K1s.placeholder" = "Nouveau mot de passe";
+
+/* Class = "UINavigationItem"; title = "Change Master Key"; ObjectID = "JKD-iF-iwA"; Note = "Title of the dialog for changing the database's master key."; */
+"JKD-iF-iwA.title" = "Modifier la clé maître";
+
+/* Class = "UITextField"; placeholder = "No Key File"; ObjectID = "M9Q-v8-e6Q"; Note = "Placeholder: don't use key file (should match the No Key File option in key file picker)."; */
+"M9Q-v8-e6Q.placeholder" = "Aucun fichier-clé";
+
+/* Class = "UITextField"; placeholder = "Repeat Password"; ObjectID = "SHG-X2-fHH"; Note = "Placeholder: the second text field for changing the master password"; */
+"SHG-X2-fHH.placeholder" = "Répéter le mot de passe";
+

--- a/KeePassium/database/fr.lproj/ChooseDatabaseVC.strings
+++ b/KeePassium/database/fr.lproj/ChooseDatabaseVC.strings
@@ -1,0 +1,18 @@
+/* Class = "UIBarButtonItem"; 2o3-sG-Pcm.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Help"; ObjectID = "2o3-sG-Pcm"; Note = "Action: show help pages (at the moment shows the About screen)"; */
+"2o3-sG-Pcm.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Aide";
+
+/* Class = "UILabel"; text = "No database files"; ObjectID = "5Md-DB-C5P"; Note = "Placeholder shown when there are no database files available"; */
+"5Md-DB-C5P.text" = "Aucun fichier de base de données";
+
+/* Class = "UIBarButtonItem"; lnO-nD-gvh.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Sort Order"; ObjectID = "lnO-nD-gvh"; Note = "Action: show sorting settings of database files"; */
+"lnO-nD-gvh.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Ordre de tri";
+
+/* Class = "UIBarButtonItem"; oee-CI-r2x.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Settings"; ObjectID = "oee-CI-r2x"; Note = "Action: show app settings"; */
+"oee-CI-r2x.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Réglages";
+
+/* Class = "UIBarButtonItem"; title = "Add Database"; ObjectID = "qPq-UR-uZs"; Note = "Action: add database (either an existing file or create a new one)"; */
+"qPq-UR-uZs.title" = "Ajouter une base de données";
+
+/* Class = "UINavigationItem"; title = "Databases"; ObjectID = "UI0-Lh-wTj"; Note = "Title of the database picker list"; */
+"UI0-Lh-wTj.title" = "Bases de données";
+

--- a/KeePassium/database/fr.lproj/ChooseKeyFileVC.strings
+++ b/KeePassium/database/fr.lproj/ChooseKeyFileVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UIButton"; normalTitle = "Add Key File"; ObjectID = "8aU-C3-c3r"; */
+"8aU-C3-c3r.normalTitle" = "Ajouter un fichier clé";
+
+/* Class = "UINavigationItem"; title = "Choose Key File"; ObjectID = "dAQ-9p-8Y9"; */
+"dAQ-9p-8Y9.title" = "Choisir un fichier clé";
+
+/* Class = "UILabel"; text = "Use only password"; ObjectID = "Ftb-fa-Dvb"; Note = "Explanation of the default option in key file picker: don't use key files."; */
+"Ftb-fa-Dvb.text" = "Utiliser uniquement le mot de passe";
+
+/* Class = "UILabel"; text = "No Key File"; ObjectID = "tGm-oo-awN"; Note = "Title of the default option in key file picker: don't use key files."; */
+"tGm-oo-awN.text" = "Aucun fichier-clé";
+

--- a/KeePassium/database/fr.lproj/DatabaseCreatorVC.strings
+++ b/KeePassium/database/fr.lproj/DatabaseCreatorVC.strings
@@ -1,0 +1,27 @@
+/* Class = "UILabel"; text = "Database File Name"; ObjectID = "2iK-ct-ygq"; */
+"2iK-ct-ygq.text" = "Nom du fichier de la base de données";
+
+/* Class = "UIButton"; accessibilityLabel = "Show Diagnostics"; ObjectID = "bNa-R0-f67"; */
+"bNa-R0-f67.accessibilityLabel" = "Afficher les diagnostics";
+
+/* Class = "UIButton"; normalTitle = "Save Database"; ObjectID = "h6C-CG-RVI"; Note = "Action: save the new database (will show a file picker dialog)."; */
+"h6C-CG-RVI.normalTitle" = "Enregistrer la base de données";
+
+/* Class = "UITextField"; placeholder = "No Key File"; ObjectID = "pvt-FS-0Yx"; Note = "Placeholder: don't use key file (should match the No Key File option in key file picker)."; */
+"pvt-FS-0Yx.placeholder" = "Aucun fichier-clé";
+
+/* Class = "UITextField"; placeholder = "Password"; ObjectID = "uHk-Yt-mBh"; Note = "Placeholder: master password of the database"; */
+"uHk-Yt-mBh.placeholder" = "Mot de passe";
+
+/* Class = "UILabel"; text = "Master Key"; ObjectID = "VjQ-di-Ilx"; Note = "Common title for the password/key file fields."; */
+"VjQ-di-Ilx.text" = "Clé maîtresse";
+
+/* Class = "UITextField"; placeholder = "e.g. MyPasswords"; ObjectID = "XNL-lc-2Ti"; Note = "Default name for a new database."; */
+"XNL-lc-2Ti.placeholder" = "Ex: mon mot de passe";
+
+/* Class = "UITextField"; text = "MyPasswords"; ObjectID = "XNL-lc-2Ti"; Note = "Default name for a new database."; */
+"XNL-lc-2Ti.text" = "MonMotsDePasse";
+
+/* Class = "UILabel"; text = "Will use kdbx4 format (Argon2+ChaCha20)"; ObjectID = "XVR-1N-ywy"; Note = "Hint about the default format of new databases."; */
+"XVR-1N-ywy.text" = "Utilisera le format kdbx4 (Argon2+ChaChaCha20)";
+

--- a/KeePassium/database/fr.lproj/UnlockDatabaseVC.strings
+++ b/KeePassium/database/fr.lproj/UnlockDatabaseVC.strings
@@ -1,0 +1,24 @@
+/* Class = "UITextField"; placeholder = "Password"; ObjectID = "CuN-tE-lAG"; Note = "Placeholder: database password"; */
+"CuN-tE-lAG.placeholder" = "Mot de passe";
+
+/* Class = "UIViewController"; title = "Unlock Database"; ObjectID = "eAa-Z5-pdq"; Note = "Title of the database unlocker dialog."; */
+"eAa-Z5-pdq.title" = "Déverrouiller la base de données";
+
+/* Class = "UILabel"; text = "Database was closed by a timer."; ObjectID = "epu-yU-Lyg"; Note = "Notification message shown by database lock timer."; */
+"epu-yU-Lyg.text" = "La base de données a été fermée par un minuteur.";
+
+/* Class = "UIButton"; normalTitle = "Upgrade to Premium"; ObjectID = "i6N-fq-JbM"; Note = "Action: open upgrade screen. Please avoid money-related words like 'buy' or 'purchase'.  If there is no good translation for the 'Upgrade' call for action, it's ok to replace it with 'get', or even reduce the phrase to  'Premium'."; */
+"i6N-fq-JbM.normalTitle" = "Passer à la version Premium";
+
+/* Class = "UILabel"; text = "Will use the remembered master key."; ObjectID = "K3Y-ON-C19"; Note = "Hint shown below the Unlock button, when not asking for master password/key file."; */
+"K3Y-ON-C19.text" = "Utilisera la clé principale mémorisée.";
+
+/* Class = "UIButton"; normalTitle = "Unlock"; ObjectID = "l45-hq-1lr"; */
+"l45-hq-1lr.normalTitle" = "Déverrouiller";
+
+/* Class = "UITextField"; placeholder = "No Key File"; ObjectID = "mYY-hP-3vH"; Note = "Placeholder: don't use key file (should match the No Key File option in key file picker)."; */
+"mYY-hP-3vH.placeholder" = "Aucun fichier-clé";
+
+/* Class = "UIButton"; accessibilityLabel = "Show Diagnostics"; ObjectID = "nrD-QC-R8N"; Note = "Action to show detailed diagnostics about the current error."; */
+"nrD-QC-R8N.accessibilityLabel" = "Afficher les diagnostics";
+

--- a/KeePassium/database/group/EditGroupVC.swift
+++ b/KeePassium/database/group/EditGroupVC.swift
@@ -70,7 +70,7 @@ class EditGroupVC: UIViewController, Refreshable {
         case .edit:
             title = LString.titleEditGroup
         }
-        group?.accessed()
+        group?.touch(.accessed)
         refresh()
     }
     
@@ -150,7 +150,7 @@ class EditGroupVC: UIViewController, Refreshable {
             return
         }
         group.name = nameTextField.text ?? ""
-        group.modified()
+        group.touch(.modified, updateParents: false)
         DatabaseManager.shared.startSavingDatabase()
     }
     

--- a/KeePassium/database/group/ViewGroupVC.swift
+++ b/KeePassium/database/group/ViewGroupVC.swift
@@ -67,6 +67,7 @@ open class ViewGroupVC: UITableViewController, Refreshable {
         let viewGroupVC = ViewGroupVC.instantiateFromStoryboard()
         viewGroupVC.group = group
         viewGroupVC.loadingWarnings = loadingWarnings
+        group?.touch(.accessed)
         return viewGroupVC
     }
     
@@ -723,9 +724,8 @@ open class ViewGroupVC: UITableViewController, Refreshable {
             {
                 [weak self] _ in
                 guard let database = targetGroup.database else { return }
-                targetGroup.accessed()
-                targetGroup.modified()
                 database.delete(group: targetGroup)
+                targetGroup.touch(.accessed)
                 self?.saveDatabase()
             }
             confirmationAlert.addAction(deleteAction)
@@ -740,9 +740,8 @@ open class ViewGroupVC: UITableViewController, Refreshable {
             {
                 [weak self] _ in
                 guard let database = targetEntry.database else { return }
-                targetEntry.accessed()
-                targetEntry.modified()
                 database.delete(entry: targetEntry)
+                targetEntry.touch(.accessed)
                 if isDeletingShownEntry && !(self?.splitViewController?.isCollapsed ?? true) {
                     self?.handleItemSelection(indexPath: nil) 
                 }

--- a/KeePassium/database/group/fr.lproj/EditGroupVC.strings
+++ b/KeePassium/database/group/fr.lproj/EditGroupVC.strings
@@ -1,0 +1,6 @@
+/* Class = "UITextField"; placeholder = "Group Name"; ObjectID = "jea-zX-9LD"; */
+"jea-zX-9LD.placeholder" = "Nom du groupe";
+
+/* Class = "UIButton"; normalTitle = "Change Icon"; ObjectID = "vz5-tj-l9g"; */
+"vz5-tj-l9g.normalTitle" = "Changer l'icône";
+

--- a/KeePassium/database/group/fr.lproj/ViewGroupVC.strings
+++ b/KeePassium/database/group/fr.lproj/ViewGroupVC.strings
@@ -1,0 +1,18 @@
+/* Class = "UIBarButtonItem"; 9KV-rC-1XL.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Lock Database"; ObjectID = "9KV-rC-1XL"; */
+"9KV-rC-1XL.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Verrouiller la base de données";
+
+/* Class = "UIBarButtonItem"; M5a-Ld-ZXd.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Sort Order"; ObjectID = "M5a-Ld-ZXd"; */
+"M5a-Ld-ZXd.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Ordre de tri";
+
+/* Class = "UIBarButtonItem"; qkh-6K-yQW.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Change Master Key"; ObjectID = "qkh-6K-yQW"; */
+"qkh-6K-yQW.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Modifier la clé maître";
+
+/* Class = "UILabel"; text = "This group is empty"; ObjectID = "QXa-eN-7am"; */
+"QXa-eN-7am.text" = "Ce groupe est vide";
+
+/* Class = "UIBarButtonItem"; rF3-mC-kj1.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0] = "Settings"; ObjectID = "rF3-mC-kj1"; */
+"rF3-mC-kj1.ibExternalUserDefinedRuntimeAttributesLocalizableStrings[0]" = "Réglages";
+
+/* Class = "UILabel"; text = "No entries found"; ObjectID = "tpA-i1-ah8"; */
+"tpA-i1-ah8.text" = "Aucune entrée trouvée";
+

--- a/KeePassium/database/relocation/ItemRelocationCoordinator.swift
+++ b/KeePassium/database/relocation/ItemRelocationCoordinator.swift
@@ -57,7 +57,7 @@ class ItemRelocationCoordinator: Coordinator {
             let currentGroup = self?.itemsToRelocate.first?.value?.parent
             self?.groupPicker.expandGroup(currentGroup)
         }
-
+                
         DatabaseManager.shared.addObserver(self)
     }
     
@@ -94,28 +94,32 @@ class ItemRelocationCoordinator: Coordinator {
     }
     
     private func moveItems(to destinationGroup: Group) {
-        for item in itemsToRelocate {
-            if let entry = item.value as? Entry {
+        for weakItem in itemsToRelocate {
+            guard let strongItem = weakItem.value else { continue }
+            if let entry = strongItem as? Entry {
                 entry.move(to: destinationGroup)
-            } else if let group = item.value as? Group {
+            } else if let group = strongItem as? Group {
                 group.move(to: destinationGroup)
             } else {
                 assertionFailure()
             }
+            strongItem.touch(.accessed, updateParents: true)
         }
     }
 
     private func copyItems(to destinationGroup: Group) {
-        for item in itemsToRelocate {
-            if let entry = item.value as? Entry {
+        for weakItem in itemsToRelocate {
+            guard let strongItem = weakItem.value else { continue }
+            if let entry = strongItem as? Entry {
                 let cloneEntry = entry.clone(makeNewUUID: true)
                 cloneEntry.move(to: destinationGroup)
-            } else if let group = item.value as? Group {
+            } else if let group = strongItem as? Group {
                 let cloneGroup = group.deepClone(makeNewUUIDs: true)
                 cloneGroup.move(to: destinationGroup)
             } else {
                 assertionFailure()
             }
+            strongItem.touch(.accessed, updateParents: true)
         }
     }
     

--- a/KeePassium/fr.lproj/InfoPlist.strings
+++ b/KeePassium/fr.lproj/InfoPlist.strings
@@ -1,0 +1,18 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "KeePassium";
+
+/* Bundle name */
+"CFBundleName" = "KeePassium";
+
+/* (No Comment) */
+"KeePass Database (kdb)" = "Base de données KeePass (kdb)";
+
+/* (No Comment) */
+"KeePass Database (kdbx)" = "Base de données KeePass (kdbx)";
+
+/* Privacy - Face ID Usage Description */
+"NSFaceIDUsageDescription" = "Utilisez FaceID pour déverrouiller KeePassium";
+
+/* Privacy - Photo Library Additions Usage Description */
+"NSPhotoLibraryAddUsageDescription" = "KeePassium a besoin d'une autorisation pour exporter des fichiers vers votre bibliothèque Photos.";
+

--- a/KeePassium/fr.lproj/Localizable.strings
+++ b/KeePassium/fr.lproj/Localizable.strings
@@ -1,0 +1,462 @@
+/* Action/button to unlock the App Lock with passcode */
+"[AppLock] Unlock" = "Déverrouiller";
+
+/* Hint/Description why the user is asked to provide their fingerprint. Shown in the standard Touch ID prompt. */
+"[AppLock/Biometric/Hint] Unlock KeePassium" = "Débloquer KeePassium";
+
+/* Action/button to switch from TouchID/FaceID prompt to manual input of the AppLock passcode. */
+"[AppLock/cancelBiometricAuth] Use Passcode" = "Utiliser le code d'accès";
+
+/* Action: change keyboard type to enter alphanumeric passphrases */
+"[AppLock/Passcode/KeyboardType/switchAction] 123→ABC" = "123→ABC";
+
+/* Action: change keyboard type to enter PIN numbers */
+"[AppLock/Passcode/KeyboardType/switchAction] ABC→123" = "ABC →123";
+
+/* Name of biometric authentication method. Trademarked, do not translate unless Apple traslated it to your language. */
+"[BiometricAuthType] Face ID" = "Face ID";
+
+/* Name of biometric authentication method. Trademarked, do not translate unless Apple traslated it to your language. */
+"[BiometricAuthType] Touch ID" = "Touch ID";
+
+/* Warning when trying to add a random file as a database. [fileName: String] */
+"[Database/Add] Selected file \"%@\" does not look like a database." = "Le fichier sélectionné \"%@\" ne semble pas être une base de données.";
+
+/* Hint shown when both password and key file are empty. */
+"[Database/Create] Please enter a password or choose a key file." = "Veuillez entrer un mot de passe ou choisir un fichier de clé.";
+
+/* Action/button to create a new database */
+"[Database/Create/action] Create Database" = "Créer une base de données";
+
+/* Note for a sample entry */
+"[Database/Create/TemplateEntry/notes] You can also store some notes, if you like." = "Vous pouvez également stocker des notes, si vous le souhaitez.";
+
+/* Password for a sample entry. Translation is optional. */
+"[Database/Create/TemplateEntry/password] pa$$word" = "pa$$word";
+
+/* Title for a sample entry */
+"[Database/Create/TemplateEntry/title] Sample Entry" = "Échantillon d'entrée";
+
+/* User name for a sample entry. Set it to a typical person name for your language ( https://en.wikipedia.org/wiki/List_of_placeholder_names_by_language). */
+"[Database/Create/TemplateEntry/userName] john.smith" = "françois.pignon";
+
+/* Predefined group in a new database */
+"[Database/Create/TemplateGroup/title] Email" = "Courriel";
+
+/* Predefined group in a new database */
+"[Database/Create/TemplateGroup/title] Finance" = "Finance";
+
+/* Predefined group in a new database */
+"[Database/Create/TemplateGroup/title] General" = "Général";
+
+/* Predefined group in a new database */
+"[Database/Create/TemplateGroup/title] Internet" = "Internet";
+
+/* Predefined group in a new database */
+"[Database/Create/TemplateGroup/title] Network" = "Réseau";
+
+/* Predefined `Operating system` group in a new database */
+"[Database/Create/TemplateGroup/title] OS" = "Système d'exploitation";
+
+/* Title of a form for creating a database */
+"[Database/Create/title] Create Database" = "Créer une base de données";
+
+/* Message to confirm deletion of a database file. (This deletes the file itself) */
+"[Database/Delete/Confirm/text] Delete database file?\n Make sure you have a backup." = "Supprimer le fichier de la base de données?\n Assurez-vous d'avoir une sauvegarde.";
+
+/* Status message: loading a database */
+"[Database/Loading/Status] Loading..." = "Chargement en cours…";
+
+/* Notification after changing database master key */
+"[Database/MasterKey/changed] Master key successfully changed" = "La clé principale a été modifiée avec succès";
+
+/* Action/button */
+"[Database/Open/action] Open Database" = "Ouvrir une base de données";
+
+/* Action/button to close current database (for example, when leaving the root group). NOTE: closing does not necessarily lock the database. */
+"[Database/Opened/action] Close" = "Fermer";
+
+/* Action/button to lock current database (the next time, it will ask for the master key). */
+"[Database/Opened/action] Lock Database" = "Verrouiller la base de données";
+
+/* Action: lock database */
+"[Database/Opened/Warning/action] Close Database" = "Fermer la base de données";
+
+/* Action: ignore warnings and proceed to work with the database */
+"[Database/Opened/Warning/action] Ignore and Continue" = "Ignorer et continuer";
+
+/* Status message: name of the app that was last to write/create the database file. [lastUsedAppName: String] */
+"[Database/Opened/Warning/lastEdited] Database was last edited by: %@" = "La dernière modification de la base de données a été effectuée par : %@";
+
+/* Title of a warning message, shown after opening a problematic database */
+"[Database/Opened/Warning/title] Your database is ready, but there was an issue." = "Votre base de données est prête, mais il y a eu un problème.";
+
+/* Message to confirm removal of database file from the app. (This keeps the file, but removes its reference from the app.) */
+"[Database/Remove/Confirm/text] Remove database from the list?\n The file will remain intact and you can add it again later." = "Retirer la base de données de la liste ?\n Le fichier restera intact et vous pourrez l'ajouter plus tard.";
+
+/* Status message: finished saving a database */
+"[Database/Saving/Status] Done" = "Fait";
+
+/* Status message: saving a database */
+"[Database/Saving/Status] Saving..." = "Sauvegarde...";
+
+/* Error message related to key file. [errorDetails: String] */
+"[Database/Unlock] Key file error: %@" = "Erreur de fichier de clé: %@";
+
+/* Action: choose a username from a list */
+"[EditEntry/UserName/choose]" = "Choisir";
+
+/* Title of a list with attached files */
+"[Entry/Attachments/title] Attached Files" = "Fichiers joints";
+
+/* Action/button to create a new entry in the current group */
+"[Entry/Create/action] Create Entry" = "Créer une entrée";
+
+/* Default name of a newly created entry field */
+"[Entry/Edit/CreateField/defaultName] Field Name" = "Nom du champ";
+
+/* Name of an entry field */
+"[Entry/Field/name] Notes" = "Remarques";
+
+/* Name of an entry field */
+"[Entry/Field/name] Password" = "Mot de passe";
+
+/* Name of an entry field */
+"[Entry/Field/name] Title" = "Titre";
+
+/* Name of an entry field */
+"[Entry/Field/name] URL" = "URL";
+
+/* Name of an entry field */
+"[Entry/Field/name] User Name" = "Nom d'utilisateur";
+
+/* Status message: loading file to be attached to an entry */
+"[Entry/Files/Add] Loading attachment file" = "Chargement du fichier joint";
+
+/* Confirmation message to replace an existing entry attachment with a new one. */
+"[Entry/Files/Add] Replace existing attachment?" = "Remplacer la pièce jointe existante ?";
+
+/* Explanation for replacing the only attachment of KeePass1 entry */
+"[Entry/Files/Add] This database supports only one attachment per entry, and there is already one." = "Cette base de données ne supporte qu'une seule pièce jointe par entrée, et il y en a déjà une.";
+
+/* Title of a dialog for renaming an attached file */
+"[Entry/Files/Rename/title] Rename File" = "Renommer Le Fichier";
+
+/* Title of a field with entry creation date and time */
+"[Entry/History] Creation Date" = "Date de création";
+
+/* Title of a field with date and time when the entry will no longer be valid. 'Never' is also a possible value */
+"[Entry/History] Expiry Date" = "Date d'expiration";
+
+/* Title of a field with date and time when the entry was last accessed/viewed */
+"[Entry/History] Last Access Date" = "Date du dernier accès";
+
+/* Title of a field with entry's last modification date and time */
+"[Entry/History] Last Modification Date" = "Date de dernière modification";
+
+/* Title of a list with previous versions/revisions of an entry. */
+"[Entry/History] Previous Versions" = "Versions précédentes";
+
+/* Expiry Date of an entry which does not expire. */
+"[Entry/History/ExpiryDate] Never" = "Jamais";
+
+/* Default title of a new entry */
+"[Entry/New/defaultTitle] New Entry" = "Nouvelle entrée";
+
+/* Action to start editing an entry */
+"[Entry/View] Edit Entry" = "Modifier l'entrée";
+
+/* A suggestion shown after specific file errors (either databases or key files). */
+"[File/PermissionDenied] Try to remove the file from the app, then add it again." = "Essayez de supprimer le fichier de l'application, puis ajoutez-le à nouveau.";
+
+/* Field title */
+"[FileInfo/Field/title] Creation Date" = "Date de création";
+
+/* Field title */
+"[FileInfo/Field/title] File Location" = "Emplacement du fichier";
+
+/* Field title */
+"[FileInfo/Field/title] File Name" = "Nom du fichier";
+
+/* Field title */
+"[FileInfo/Field/title] File Size" = "Taille Du Fichier";
+
+/* Field title */
+"[FileInfo/Field/title] Last Modification Date" = "Date de dernière modification";
+
+/* Title of a field with an error message */
+"[FileInfo/Field/valueError] Error" = "Erreur";
+
+/* Title of the dialog for picking the destination group for move/copy operations */
+"[General/DestinationGroup/title] Choose a Destination" = "Choisissez la destination";
+
+/* Action/button to cancel whatever is going on */
+"[Generic] Cancel" = "Annuler";
+
+/* Action/button to write an email to support */
+"[Generic] Contact Us" = "Contactez-nous";
+
+/* Action/button to move an item (to another group/folder/etc) */
+"[Generic] Copy" = "Copier";
+
+/* Action/button to delete an item (destroys the item/file) */
+"[Generic] Delete" = "Supprimer";
+
+/* Action/button to discard any unsaved changes */
+"[Generic] Discard" = "Annuler";
+
+/* Action/button to close an error message. */
+"[Generic] Dismiss" = "Ignorer";
+
+/* Action/button to finish (editing) and keep changes */
+"[Generic] Done" = "Fait";
+
+/* Action/button to edit an item */
+"[Generic] Edit" = "Éditer";
+
+/* Action/button to export an item to another app */
+"[Generic] Export" = "Exporter";
+
+/* Action/button to move an item (to another group/folder/etc) */
+"[Generic] Move" = "Déplacer";
+
+/* Action/button: generic OK */
+"[Generic] OK" = "OK";
+
+/* Action/button to rename an item */
+"[Generic] Rename" = "Renommer";
+
+/* Action/button to replace an item with another one */
+"[Generic] Replace" = "Remplacer";
+
+/* Action/button to show additional information about an error or item */
+"[Generic] Show Details" = "Voir les détails";
+
+/* Message to confirm deletion of an item. */
+"[Generic/ConfirmDelete/title] Are you sure?" = "Êtes-vous certain ?";
+
+/* Notification text when the user tries to close a document with unsaved changes */
+"[Generic/Edit/Aborting/text] Discard unsaved changes?" = "Annuler les modifications non enregistrées ?";
+
+/* Title of a notification when the user tries to close a document with unsaved changes */
+"[Generic/Edit/Aborting/title] There are unsaved changes" = "Il y a des modifications non enregistrées";
+
+/* Action/button to delete a file (destroys the file forever) */
+"[Generic/File] Delete" = "Supprimer";
+
+/* Action/button to remove a file from the app (the file remains, but the app forgets about it) */
+"[Generic/File] Remove" = "Dissocier";
+
+/* Title of an error message about file export */
+"[Generic/File/title] Export Error" = "Erreur d'exportation";
+
+/* Title of an error message about file import */
+"[Generic/File/title] Import Error" = "Erreur d'importation";
+
+/* Title of an error message notification */
+"[Generic/title] Error" = "Erreur";
+
+/* Title of an error message about iOS system keychain */
+"[Generic/title] Keychain Error" = "Erreur du trousseau";
+
+/* Title of an warning message */
+"[Generic/title] Warning" = "Avertissement";
+
+/* Action/button to create a new sub-group in the current group */
+"[Group/Create/action] Create Group" = "Créer un groupe";
+
+/* Title of a form for creating a group */
+"[Group/Create/title] Create Group" = "Créer un groupe";
+
+/* Title of a form for editing a group */
+"[Group/Edit/title] Edit Group" = "Modifier le Groupe";
+
+/* Default name of a new group */
+"[Group/New/defaultName] New Group" = "Nouveau groupe";
+
+/* Name of an entry/group category (visual style): default one, like in KeePass */
+"[ItemCategory] Default (KeePass)" = "Par défaut (KeePass)";
+
+/* Message to confirm deletion of a key file. */
+"[KeyFile/Delete/Confirm/text] Delete key file?\n Make sure you have a backup." = "Supprimer le fichier clé?\n Assurez-vous d'avoir une sauvegarde.";
+
+/* Title of an announcement about the Pro version */
+"[News/2019/10/ProVersionReleaseNews/title] KeePassium Pro" = "KeePassium Pro";
+
+/* Message shown when opening an announcement in AutoFill */
+"[News/AutoFill/stubText] Please open the main app for the full announcement." = "Veuillez ouvrir l'application principale pour l'annonce complète.";
+
+/* Explanation of the premium feature */
+"[Premium/Benefits/AttachmentPreview/details]" = "Prévisualiser les fichiers attachés directement dans KeePassium et ne laisser aucune trace dans d'autres applications. (Fonctionne avec des images, des documents, des archives et plus.)";
+
+/* Title of a premium feature */
+"[Premium/Benefits/AttachmentPreview/title]" = "Aperçu sans trace";
+
+/* Explanation of the premium feature */
+"[Premium/Benefits/DatabaseTimeout/details]" = "Fatigué de taper votre mot de passe maître ? Gardez votre base de données ouverte plus longtemps et débloquez-la en un seul clic.";
+
+/* Title of a premium feature */
+"[Premium/Benefits/DatabaseTimeout/title]" = "Gagnez du temps";
+
+/* Explanation of the premium feature */
+"[Premium/Benefits/Maintenance/details]" = "Gardez KeePassium amélioré, maintenu et sans publicité.";
+
+/* Title of a premium feature */
+"[Premium/Benefits/Maintenance/title]" = "Gardez-le brillant";
+
+/* Explanation of the premium feature */
+"[Premium/Benefits/MultiDB/details]" = "Ajoutez plusieurs bases de données et basculez rapidement entre elles.";
+
+/* Title of a premium feature */
+"[Premium/Benefits/MultiDB/title]" = "Synchroniser avec l'équipe";
+
+/* Explanation of the premium feature */
+"[Premium/Benefits/Support/details]" = "Le soutien de la communauté n'a pas de caractère obligatoire. Avec la version Premium, obtenez des réponses et des solutions directement du développeur.";
+
+/* Title of a premium feature */
+"[Premium/Benefits/Support/title]" = "Échanger avec une assistance technique consciencieuse";
+
+/* Status: special premium for beta-testing environment is active */
+"[Premium/status] Beta testing" = "Fonctionnalités Beta";
+
+/* Status: premium subscription has expired. For example: `Expired 1 day ago`. [timeFormatted: String, includes the time unit (day, hour, minute)] */
+"[Premium/status] Expired %@ ago. Please renew." = "Expiré il y a %@ . Veuillez renouveler.";
+
+/* Status: scheduled renewal date of a premium subscription. For example: `Next renewal on 1 Jan 2050`. [expiryDateString: String] */
+"[Premium/status] Next renewal on %@" = "Prochain renouvellement le %@";
+
+/* Status: validity period of once-and-forever premium */
+"[Premium/status] Valid forever" = "Valable à vie";
+
+/* Error message: AppStore returned no available in-app purchase options */
+"[Premium/Upgrade] Hmm, there are no upgrades available. This should not happen, please contact support." = "Hmm, il n'y a aucune mise à jour disponible. Cela ne devrait pas se produire, veuillez contacter le support.";
+
+/* Action/button to start choosing premium versions and possibly buying one */
+"[Premium/Upgrade/action] Upgrade to Premium" = "Passer à la version Premium";
+
+/* Message shown when in-app purchase is deferred until parental approval. */
+"[Premium/Upgrade/Deferred/text] Thank you! You can use KeePassium while purchase is awaiting approval from a parent" = "Merci! Vous pouvez utiliser KeePassium pendant que l'achat attend l'approbation d'un parent";
+
+/* Description of a premium option. Lowercase. For example 'Business Premium / with priority support'. */
+"[Premium/Upgrade/description] with priority support" = "avec support prioritaire";
+
+/* Product price for monthly premium subscription. [localizedPrice: String] */
+"[Premium/Upgrade/price] %@ / month" = "%@ / mois";
+
+/* Product price for annual premium subscription. [localizedPrice: String] */
+"[Premium/Upgrade/price] %@ / year" = "%@ / an";
+
+/* Product price for once-and-forever premium. [localizedPrice: String] */
+"[Premium/Upgrade/price] %@ once" = "%@ une fois";
+
+/* Status message when downloading available in-app purchases */
+"[Premium/Upgrade/Progress] Contacting AppStore..." = "Contacter l'App Store...";
+
+/* Status: in-app purchase started */
+"[Premium/Upgrade/Progress] Purchasing..." = "Achat en cours...";
+
+/* Text of the message shown after in-app purchase was successfully restored */
+"[Premium/Upgrade/Restored/text] Upgrade successful, enjoy the app!" = "Mise à niveau réussie, profitez de l'application !";
+
+/* Title of the message shown after in-app purchase was successfully restored */
+"[Premium/Upgrade/Restored/title] Purchase Restored" = "Achat restauré";
+
+/* Text of an error message: there were no in-app purchases that can be restored */
+"[Premium/Upgrade/RestoreFailed/text] No previous purchase could be restored." = "Aucun achat précédent n'a pu être restauré.";
+
+/* Title of an error message: there were no in-app purchases that can be restored */
+"[Premium/Upgrade/RestoreFailed/title] Sorry" = "Désolé";
+
+/* Status: how long the app has been used during some time period. For example: `App being useful: 1hr/month, about 12hr/year`. [monthlyUsage: String, annualUsage: String — already include the time unit (hours, minutes)] */
+"[Premium/usage] App being useful: %@/month, that is around %@/year." = "Application utile : %1$@/mois, soit environ %2$@/an.";
+
+/* Description/advertisement for the `Biometric Unlock` premium feature */
+"[PremiumFeature/BiometricAppLock/description] Quickly access your passwords using Face ID/Touch ID in the premium version." = "Accédez rapidement à vos mots de passe en utilisant Face ID/Touch ID dans la version Premium.";
+
+/* Title of a premium feature: ability to use Touch ID / Face ID in AppLock settings (In Title Case) */
+"[PremiumFeature/BiometricAppLock/title] Biometric Unlock" = "Déverrouillage biométrique";
+
+/* Description/advertisement for the `Long Database Timeouts` premium feature */
+"[PremiumFeature/LongDBTimeouts/description] Save time entering your complex master passwords — keep your database open longer in the premium version." = "Gagnez du temps en entrant vos mots de passe principaux complexes — gardez votre base de données ouverte plus longtemps dans la version premium.";
+
+/* Title of a premium feature: ability to set long delays in Database Lock Timeout settings (In Title Case) */
+"[PremiumFeature/LongDBTimeouts/title] Long Database Timeouts" = "Délai d'attente long de la base de données";
+
+/* Description/advertisement for the `Multiple Databases` premium feature */
+"[PremiumFeature/MultiDB/description] Easily switch between databases in the premium version." = "Basculer facilement entre les bases de données dans la version premium.";
+
+/* Title of a premium feature: ability to use multiple databases (In Title Case) */
+"[PremiumFeature/MultiDB/title] Multiple Databases" = "Bases de données multiples";
+
+/* Description/advertisement for the `Preview Attachments` premium feature */
+"[PremiumFeature/Preview/description] Preview images and documents directly in the app, in the premium version." = "Aperçu des images et des documents directement dans l'application, dans la version premium.";
+
+/* Title of a premium feature: ability to preview some attached files directly in the app (In Title Case) */
+"[PremiumFeature/Preview/title] Preview Attachments" = "Aperçu des pièces jointes";
+
+/* Action/button to make password visible as plain-text */
+"[ProtectedTextField] Show Password" = "Afficher le mot de passe";
+
+/* Settings switch: whether AppLock is allowed to use Touch ID/Face ID. Example: 'Use Touch ID'. [biometryTypeName: String] */
+"[Settings/AppLock/Biometric/title] Use %@" = "Utiliser %@";
+
+/* Settings: subtitle of the `App Protection` section. biometryTypeName will be either 'Touch ID' or 'Face ID'. [biometryTypeName: String] */
+"[Settings/AppLock/subtitle] App Lock, %@, timeout" = "Verrouillage de l'application, %@, délai d'attente";
+
+/* Settings: subtitle of the `App Protection` section when biometric auth is not available. */
+"[Settings/AppLock/subtitle] App Lock, passcode, timeout" = "Verrouillage de l'application, mot de passe, délai de verrouillage";
+
+/* Action to delete all backup files from the app. `ALL` is in capitals as a highlight. [backupFileCount: Int] */
+"[Settings/Backup] Delete ALL Backup Files (%d)" = "Supprimer tous les fichiers de sauvegarde (%d)";
+
+/* Status message: there are no backup files to delete */
+"[Settings/Backup] No Backup Files Found" = "Pas de fichier de sauvegarde trouvé";
+
+/* Confirmation dialog message to delete all backup files */
+"[Settings/Backup/Delete/title] Delete all backup files?" = "Supprimer tous les fichiers de sauvegarde ?";
+
+/* Text of the success message for `Clear Key File Associations` button */
+"[Settings/ClearKeyFileAssociations/Cleared/text] Associations between key files and databases have been removed." = "Les associations entre les fichiers clés et les bases de données ont été supprimées.";
+
+/* Title of the success message for `Clear Key File Associations` button */
+"[Settings/ClearKeyFileAssociations/Cleared/title] Cleared" = "Nettoyé";
+
+/* Text of the success message for `Clear Master Keys` button */
+"[Settings/ClearMasterKeys/Cleared/text] All master keys have been deleted." = "Toutes les clés maîtresses ont été supprimées.";
+
+/* Title of the success message for `Clear Master Keys` button */
+"[Settings/ClearMasterKeys/Cleared/title] Cleared" = "Nettoyé";
+
+/* Description of the clipboard/pasteboard timeout. */
+"[Settings/ClipboardTimeout/description] When you copy some text from an entry, the app will automatically clear your clipboard (pasteboard) after this time." = "Lorsque vous copiez du texte depuis une entrée, l'application effacera automatiquement votre presse-papiers après ce délai.";
+
+/* Description of the Database Lock Timeout */
+"[Settings/DatabaseLockTimeout/description] If you are not interacting with the app for some time, the database will be closed for your safety. To open it, you will need to enter its master password again." = "Si vous n'interagissez pas avec l'application depuis un certain temps, la base de données sera fermée pour votre sécurité. Pour l'ouvrir, vous devrez entrer à nouveau son mot de passe principal.";
+
+/* Title of a settings section about making backup files */
+"[Settings/FileLists/Backup/title] Backup" = "Sauvegarde";
+
+/* Title of a settings section about file order in lists */
+"[Settings/FileLists/Sorting/title] Sorting" = "Tri en cours";
+
+/* Title of a settings section: which entry field to show along with entry title */
+"[Settings/GroupViewer] Entry Subtitle" = "Sous-titre de l'entrée";
+
+/* Title of a settings section: sort order of groups and entries in a list */
+"[Settings/GroupViewer] Sort Order" = "Ordre de tri";
+
+/* Template text of a bug report email */
+"[Support/template] (Please describe the problem here)" = "(Veuillez décrire le problème ici)";
+
+/* Action/button to add database to the app */
+"Add Database" = "Ajouter une base de données";
+
+/* Title of a window where the user selects a file to be opened/added to the app */
+"Choose Database" = "Choisir la base de données";
+
+/* Action/button */
+"Import Database" = "Importer une base de données";
+
+/* Warning message when the user tries to use a database as a key file */
+"KeePass database should not be used as key file. Please pick a different file." = "La base de données KeePass ne doit pas être utilisée comme fichier clé. Veuillez choisir un autre fichier.";
+

--- a/KeePassium/general/Base.lproj/AboutVC.storyboard
+++ b/KeePassium/general/Base.lproj/AboutVC.storyboard
@@ -65,7 +65,7 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Feedback" id="7bL-fQ-OUc" userLabel="Feedback">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="TOl-DA-gYc" detailTextLabel="jzd-La-4YT" imageView="UGg-sp-gxz" style="IBUITableViewCellStyleSubtitle" id="lcp-fz-TzI">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="TOl-DA-gYc" detailTextLabel="kae-Kb-5ZU" imageView="UGg-sp-gxz" style="IBUITableViewCellStyleSubtitle" id="lcp-fz-TzI">
                                         <rect key="frame" x="0.0" y="118" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lcp-fz-TzI" id="hgA-pl-wja">
@@ -86,16 +86,15 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="l10nTable" value="AboutVC"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="info@keepassium.com" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="jzd-La-4YT" customClass="Xcode11GM_LocalizedLabel" customModule="KeePassium" customModuleProvider="target">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="info@keepassium.com" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="kae-Kb-5ZU">
                                                     <rect key="frame" x="60" y="25.5" width="126.5" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                     <color key="textColor" name="AuxiliaryText"/>
                                                     <nil key="highlightedColor"/>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="l10nKey" value="jzd-La-4YT.text"/>
-                                                        <userDefinedRuntimeAttribute type="string" keyPath="l10nTable" value="AboutVC"/>
-                                                    </userDefinedRuntimeAttributes>
+                                                    <attributedString key="userComments">
+                                                        <fragment content="#bc-ignore!"/>
+                                                    </attributedString>
                                                 </label>
                                                 <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="email-us-listitem" id="UGg-sp-gxz">
                                                     <rect key="frame" x="16" y="7.5" width="29" height="29"/>

--- a/KeePassium/general/RootSplitVC.swift
+++ b/KeePassium/general/RootSplitVC.swift
@@ -6,7 +6,7 @@
 //  by the Free Software Foundation: https://www.gnu.org/licenses/).
 //  For commercial licensing, please contact the author.
 
-import UIKit
+import KeePassiumLib
 
 class RootSplitVC: UISplitViewController, UISplitViewControllerDelegate {
 
@@ -27,5 +27,32 @@ class RootSplitVC: UISplitViewController, UISplitViewControllerDelegate {
             return true 
         }
         return false
+    }
+}
+
+extension RootSplitVC: FileKeeperDelegate {
+    func shouldResolveImportConflict(
+        target: URL,
+        handler: @escaping (FileKeeper.ConflictResolution) -> Void)
+    {
+        let fileName = target.lastPathComponent
+        let choiceAlert = UIAlertController(
+            title: fileName,
+            message: LString.fileAlreadyExists,
+            preferredStyle: .alert)
+        let actionOverwrite = UIAlertAction(title: LString.actionOverwrite, style: .destructive) {
+            (action) in
+            handler(.overwrite)
+        }
+        let actionRename = UIAlertAction(title: LString.actionRename, style: .default) { (action) in
+            handler(.rename)
+        }
+        let actionAbort = UIAlertAction(title: LString.actionCancel, style: .cancel) { (action) in
+            handler(.abort)
+        }
+        choiceAlert.addAction(actionOverwrite)
+        choiceAlert.addAction(actionRename)
+        choiceAlert.addAction(actionAbort)
+        present(choiceAlert, animated: true)
     }
 }

--- a/KeePassium/general/cs.lproj/AboutVC.strings
+++ b/KeePassium/general/cs.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "Licence GPL";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "Nějaké otázky? Máme odpovědi.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy deboss pattern by Daniel Beaton";
 

--- a/KeePassium/general/de.lproj/AboutVC.strings
+++ b/KeePassium/general/de.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "GPL Lizenz";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "Fragen? Wir antworten.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy Deboss-Pattern von Daniel Beaton";
 

--- a/KeePassium/general/es.lproj/AboutVC.strings
+++ b/KeePassium/general/es.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "Licencia GPL";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "¿Alguna pregunta? Tenemos las respuestas.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Patrón Fancy deboss por Daniel Beaton";
 

--- a/KeePassium/general/fr.lproj/AboutVC.strings
+++ b/KeePassium/general/fr.lproj/AboutVC.strings
@@ -1,0 +1,126 @@
+/* Class = "UITableViewSection"; headerTitle = "Feedback"; ObjectID = "7bL-fQ-OUc"; Note = "Section: user feedback about the app"; */
+"7bL-fQ-OUc.headerTitle" = "Retour sur expérience";
+
+/* Class = "UILabel"; text = "Proprietary license"; ObjectID = "7cl-Fc-8Nf"; */
+"7cl-Fc-8Nf.text" = "Licence propriétaire";
+
+/* Class = "UILabel"; text = "Icons by Icons8"; ObjectID = "7id-QT-w26"; */
+"7id-QT-w26.text" = "Icônes par Icons8";
+
+/* Class = "UILabel"; text = "Ionicons by Ionic"; ObjectID = "9lh-fA-Xgx"; */
+"9lh-fA-Xgx.text" = "Ionicons par Ionic";
+
+/* Class = "UILabel"; text = "Base32 for Swift by Norio Nomura"; ObjectID = "9MZ-zt-75x"; */
+"9MZ-zt-75x.text" = "Base32 pour Swift par Norio Nomura";
+
+/* Class = "UILabel"; text = "KeePassium does not collect any personal or analytical data nor share it with anyone."; ObjectID = "9wt-nj-TZW"; */
+"9wt-nj-TZW.text" = "KeePassium ne recueille aucune donnée personnelle ou analytique ni ne la partage avec quiconque.";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "Aig-jg-p8B"; */
+"Aig-jg-p8B.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "Do you like what you see?"; ObjectID = "AMd-x7-PDa"; Note = "First part of the 'Do you like what you see? / Leave an App Store review.\""; */
+"AMd-x7-PDa.text" = "Vous aimez ce que vous voyez?";
+
+/* Class = "UILabel"; text = "Translation by KeePassium contributors"; ObjectID = "aqX-J9-IzD"; Note = "Replace with a credit to yourself. For example: `German translation by Erika Mustermann and @JohnDoe`."; */
+"aqX-J9-IzD.text" = "Traduction par les contributeurs de KeePassium";
+
+/* Class = "UILabel"; text = "Twofish implementation by Niels Ferguson"; ObjectID = "axY-gm-XNr"; */
+"axY-gm-XNr.text" = "Implémentation de Twofish par Niels Ferguson";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "bAq-tq-nuY"; */
+"bAq-tq-nuY.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "©2019 Andrei Popleteev"; ObjectID = "bmf-Ed-H4x"; */
+"bmf-Ed-H4x.text" = "©2019 Andrei Popleteev";
+
+/* Class = "UILabel"; text = "KeePass by Dominik Reichl"; ObjectID = "CNI-b8-7Da"; */
+"CNI-b8-7Da.text" = "KeePass par Dominik Reichl";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "daJ-ma-jhe"; */
+"daJ-ma-jhe.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "dMv-Zw-y7y"; */
+"dMv-Zw-y7y.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "Custom permissive license"; ObjectID = "EWy-OI-IxL"; */
+"EWy-OI-IxL.text" = "Licence permissive personnalisée";
+
+/* Class = "UILabel"; text = "ChaCha20 & Salsa20 implementation by D. J. Bernstein"; ObjectID = "Ha8-Qv-0qg"; */
+"Ha8-Qv-0qg.text" = "Implémentation de ChaCha20 & Salsa20 par D. J. Bernstein";
+
+/* Class = "UILabel"; text = "Rijndael implementation by Szymon Stefanek"; ObjectID = "hDU-6p-Bzr"; */
+"hDU-6p-Bzr.text" = "Implémentation de Rijndael par Szymon Stefanek";
+
+/* Class = "UILabel"; text = "CC BY 3.0"; ObjectID = "hVm-qH-TAI"; */
+"hVm-qH-TAI.text" = "CC PAR 3.0";
+
+/* Class = "UILabel"; text = "CC BY-ND 3.0"; ObjectID = "iKy-z5-Ox7"; */
+"iKy-z5-Ox7.text" = "CC BY-ND 3.0";
+
+/* Class = "UITableViewSection"; headerTitle = "Privacy Policy"; ObjectID = "JbR-nf-D9o"; Note = "Section: privacy policy"; */
+"JbR-nf-D9o.headerTitle" = "Politique de confidentialité";
+
+/* Class = "UILabel"; text = "Public domain"; ObjectID = "JgR-60-OMp"; */
+"JgR-60-OMp.text" = "Domaine public";
+
+/* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
+"JRy-jy-KXb.text" = "Licence GPL";
+
+/* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
+"Kdg-Hz-XOQ.text" = "Fancy deboss pattern par Daniel Beaton";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "lht-LP-o0Y"; */
+"lht-LP-o0Y.text" = "Licence MIT";
+
+/* Class = "UITableViewSection"; headerTitle = "Credits"; ObjectID = "muG-xI-muo"; Note = "Section: acknowledgements and thank-you notes"; */
+"muG-xI-muo.headerTitle" = "Crédits";
+
+/* Class = "UITableViewController"; title = "About"; ObjectID = "NLN-lQ-bh5"; */
+"NLN-lQ-bh5.title" = "A propos";
+
+/* Class = "UILabel"; text = "CC0 license"; ObjectID = "o9e-qb-mMw"; */
+"o9e-qb-mMw.text" = "Licence CC0";
+
+/* Class = "UILabel"; text = "Public domain"; ObjectID = "QV5-N8-NRt"; */
+"QV5-N8-NRt.text" = "Domaine public";
+
+/* Class = "UILabel"; text = "CC BY 3.0"; ObjectID = "Qz4-PJ-Tra"; */
+"Qz4-PJ-Tra.text" = "CC PAR 3.0";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "Rab-wf-OQe"; */
+"Rab-wf-OQe.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "Argon2 by Daniel Dinu, Dmitry Khovratovich, Jean-Philippe Aumasson, and Samuel Neves"; ObjectID = "rDJ-4G-8Oz"; */
+"rDJ-4G-8Oz.text" = "Argon2 de Daniel Dinu, Dmitry Khovratovich, Jean-Philippe Aumasson, et Samuel Neves";
+
+/* Class = "UILabel"; text = "MIT license"; ObjectID = "sCk-Se-Vvo"; */
+"sCk-Se-Vvo.text" = "Licence MIT";
+
+/* Class = "UILabel"; text = "GzipSwift by 1024jp"; ObjectID = "sDW-ws-pQf"; */
+"sDW-ws-pQf.text" = "GzipSwift par 1024jp";
+
+/* Class = "UILabel"; text = "AEXML by Marko Tadić"; ObjectID = "sI5-AG-Y6p"; */
+"sI5-AG-Y6p.text" = "AEXML par Marko Tadić";
+
+/* Class = "UILabel"; text = "Linecons by Andrian Valeanu"; ObjectID = "SOX-Re-yl9"; */
+"SOX-Re-yl9.text" = "Linecons par Andrian Valeanu";
+
+/* Class = "UILabel"; text = "Contact Support"; ObjectID = "TOl-DA-gYc"; Note = "Action: contact us"; */
+"TOl-DA-gYc.text" = "Contacter le support technique";
+
+/* Class = "UILabel"; text = "Feather icons by Cole Bemis"; ObjectID = "tOr-N9-2UY"; */
+"tOr-N9-2UY.text" = "Icônes plume par Cole Bemis";
+
+/* Class = "UILabel"; text = "Leave an App Store review."; ObjectID = "uiw-Qh-pNp"; Note = "Second part of the 'Do you like what you see? / Leave an App Store review.\""; */
+"uiw-Qh-pNp.text" = "Laisser un avis sur l'App Store.";
+
+/* Class = "UILabel"; text = "KeyboardLayoutConstraint by James Tang"; ObjectID = "vg0-6M-OIq"; */
+"vg0-6M-OIq.text" = "KeyboardLayoutConstraint par James Tang";
+
+/* Class = "UILabel"; text = "KeePassium"; ObjectID = "Wuj-Uw-baK"; */
+"Wuj-Uw-baK.text" = "KeePassium";
+
+/* Class = "UILabel"; text = "System settings icon by Vicons Design"; ObjectID = "wYr-Ya-qAP"; */
+"wYr-Ya-qAP.text" = "Icône des paramètres système par Vicons Design";
+

--- a/KeePassium/general/fr.lproj/ChooseIconVC.strings
+++ b/KeePassium/general/fr.lproj/ChooseIconVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UINavigationItem"; title = "Choose Icon"; ObjectID = "H8v-gf-kff"; */
+"H8v-gf-kff.title" = "Choisir une icône";
+

--- a/KeePassium/general/fr.lproj/FileInfoVC.strings
+++ b/KeePassium/general/fr.lproj/FileInfoVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UITableViewController"; title = "File Info"; ObjectID = "Cu8-bv-TEu"; */
+"Cu8-bv-TEu.title" = "Info fichier";
+

--- a/KeePassium/general/fr.lproj/PasscodeInputVC.strings
+++ b/KeePassium/general/fr.lproj/PasscodeInputVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UILabel"; text = "Enter passcode"; ObjectID = "3mQ-t6-0ty"; Note = "Call for action above the passcode text field"; */
+"3mQ-t6-0ty.text" = "Entrez votre code";
+
+/* Class = "UINavigationItem"; title = "Unlock KeePassium"; ObjectID = "P3J-3c-ucU"; */
+"P3J-3c-ucU.title" = "Débloquer KeePassium";
+
+/* Class = "UIButton"; normalTitle = "Cancel"; ObjectID = "z0x-Rz-Nfj"; */
+"z0x-Rz-Nfj.normalTitle" = "Annuler";
+
+/* Class = "UITextField"; placeholder = "Passcode"; ObjectID = "ZTd-Zj-qAs"; Note = "Placeholder text in the AppLock passcode field"; */
+"ZTd-Zj-qAs.placeholder" = "Code d'accès";
+

--- a/KeePassium/general/fr.lproj/ViewDiagnosticsVC.strings
+++ b/KeePassium/general/fr.lproj/ViewDiagnosticsVC.strings
@@ -1,0 +1,9 @@
+/* Class = "UINavigationItem"; title = "Diagnostic Info"; ObjectID = "1D0-qD-Wj1"; */
+"1D0-qD-Wj1.title" = "Informations de diagnostic";
+
+/* Class = "UIBarButtonItem"; title = "Clear"; ObjectID = "icR-uK-cyC"; Note = "Action: clear diagnostic log"; */
+"icR-uK-cyC.title" = "Nettoyé";
+
+/* Class = "UIBarButtonItem"; title = "Contact Support"; ObjectID = "uAJ-Ui-Jkx"; Note = "Action: write an email to support"; */
+"uAJ-Ui-Jkx.title" = "Contacter le support technique";
+

--- a/KeePassium/general/fr.lproj/WelcomeVC.strings
+++ b/KeePassium/general/fr.lproj/WelcomeVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UIViewController"; title = "Welcome"; ObjectID = "1Nc-wz-Yqq"; Note = "Onboarding screen shown on first launch"; */
+"1Nc-wz-Yqq.title" = "Bienvenu(e)";
+
+/* Class = "UIButton"; normalTitle = "Create New Database"; ObjectID = "4wh-8O-5Ch"; */
+"4wh-8O-5Ch.normalTitle" = "Créer une nouvelle base de données";
+
+/* Class = "UILabel"; text = "KeePassium stores your passwords, credit cards and other information in an encrypted file (database). \nYou can have multiple databases, for example to separate work, family and personal accounts."; ObjectID = "PgB-6p-H0t"; */
+"PgB-6p-H0t.text" = "KeePassium stocke vos mots de passe, cartes de crédit et autres informations dans un fichier crypté (base de données). \nVous pouvez avoir plusieurs bases de données, par exemple pour séparer le travail, la famille et les comptes personnels.";
+
+/* Class = "UIButton"; normalTitle = "Add Existing Database"; ObjectID = "ZKW-2f-Xkz"; */
+"ZKW-2f-Xkz.normalTitle" = "Ajouter une base de données existante";
+

--- a/KeePassium/general/nl.lproj/AboutVC.strings
+++ b/KeePassium/general/nl.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "GPL-licentie";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "Heb je vragen? Wij hebben de antwoorden.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Gelikt deboss-patroon van Daniel Beaton";
 

--- a/KeePassium/general/ru.lproj/AboutVC.strings
+++ b/KeePassium/general/ru.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "Лицензия GPL";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "Есть вопросы? У нас есть ответы.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy deboss pattern, автор Daniel Beaton";
 

--- a/KeePassium/general/sv.lproj/AboutVC.strings
+++ b/KeePassium/general/sv.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "GPL-licens";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "Några frågor? Vi har svar.";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy deboss pattern av Daniel Beaton";
 

--- a/KeePassium/general/zh-Hans.lproj/AboutVC.strings
+++ b/KeePassium/general/zh-Hans.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "GPL 授权许可";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "有任何问题? 我们有答案。";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy deboss pattern 来自 Daniel Beaton";
 

--- a/KeePassium/general/zh-Hant.lproj/AboutVC.strings
+++ b/KeePassium/general/zh-Hant.lproj/AboutVC.strings
@@ -67,9 +67,6 @@
 /* Class = "UILabel"; text = "GPL license"; ObjectID = "JRy-jy-KXb"; */
 "JRy-jy-KXb.text" = "GPL 授權許可";
 
-/* Class = "UILabel"; text = "Any questions? We have answers."; ObjectID = "jzd-La-4YT"; */
-"jzd-La-4YT.text" = "有任何問題? 我們有答案。";
-
 /* Class = "UILabel"; text = "Fancy deboss pattern by Daniel Beaton"; ObjectID = "Kdg-Hz-XOQ"; */
 "Kdg-Hz-XOQ.text" = "Fancy deboss pattern 來自 Daniel Beaton";
 

--- a/KeePassium/premium/fr.lproj/PremiumContainerVC.strings
+++ b/KeePassium/premium/fr.lproj/PremiumContainerVC.strings
@@ -1,0 +1,6 @@
+/* Class = "UISegmentedControl"; Qkk-pB-jp6.segmentTitles[0] = "Premium"; ObjectID = "Qkk-pB-jp6"; */
+"Qkk-pB-jp6.segmentTitles[0]" = "Premium";
+
+/* Class = "UISegmentedControl"; Qkk-pB-jp6.segmentTitles[1] = "Pro"; ObjectID = "Qkk-pB-jp6"; */
+"Qkk-pB-jp6.segmentTitles[1]" = "Pro";
+

--- a/KeePassium/premium/fr.lproj/PremiumProVC.strings
+++ b/KeePassium/premium/fr.lproj/PremiumProVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UIButton"; accessibilityLabel = "Download in the App Store"; ObjectID = "5rv-SA-uRy"; */
+"5rv-SA-uRy.accessibilityLabel" = "Télécharger sur l'App Store";
+
+/* Class = "UIButton"; normalTitle = "Premium Keeper = Free upgrade\nContact us"; ObjectID = "k28-Nu-VFD"; */
+"k28-Nu-VFD.normalTitle" = "Premium Keeper = Mise à niveau gratuite\nContactez-nous";
+
+/* Class = "UILabel"; text = "KeePassium Pro"; ObjectID = "RMU-nJ-6tZ"; */
+"RMU-nJ-6tZ.text" = "KeePassium Pro";
+
+/* Class = "UILabel"; text = "KeePassium Pro is a paid version of KeePassium, and is suitable for Family Sharing and Volume Purchase Program."; ObjectID = "TAt-eQ-x30"; */
+"TAt-eQ-x30.text" = "KeePassium Pro est une version payante de KeePassium, adaptée au programme de partage familial et d’achat en volume.";
+

--- a/KeePassium/premium/fr.lproj/PremiumVC.strings
+++ b/KeePassium/premium/fr.lproj/PremiumVC.strings
@@ -1,0 +1,12 @@
+/* Class = "UIButton"; normalTitle = "Privacy Policy"; ObjectID = "Dfd-LU-ij4"; */
+"Dfd-LU-ij4.normalTitle" = "Politique de confidentialité";
+
+/* Class = "UILabel"; text = "Payment will be charged to your Apple ID account at the confirmation of purchase. \n\nSubscription automatically renews unless it is canceled at least 24 hours before the end of the current period. Your account will be charged for renewal within 24 hours prior to the end of the current period. \n\nYou can manage and cancel your subscriptions by going to your account settings on the App Store after purchase."; ObjectID = "Rkk-oi-8fO"; Note = "Standard conditions text mandated by Apple."; */
+"Rkk-oi-8fO.text" = "Le paiement sera prélevé sur votre compte Apple au moment de la confirmation de l’achat. L’abonnement est renouvelé automatiquement à moins qu’il ne soit annulé au moins 24 heures avant la fin de la période en cours. Le renouvellement sera prélevé sur votre compte dans les 24 heures précédant la fin de la période en cours. Vous pouvez gérer et annuler vos abonnements depuis les paramètres du compte dans l’App Store, une fois l’achat réalisé.";
+
+/* Class = "UIButton"; normalTitle = "Terms and Conditions"; ObjectID = "ujr-9f-eco"; */
+"ujr-9f-eco.normalTitle" = "Conditions d’utilisation";
+
+/* Class = "UIButton"; normalTitle = "Restore Purchases"; ObjectID = "yss-Xu-2XK"; */
+"yss-Xu-2XK.normalTitle" = "Restaurer les achats";
+

--- a/KeePassium/settings/appLock/fr.lproj/SettingsAppLockVC.strings
+++ b/KeePassium/settings/appLock/fr.lproj/SettingsAppLockVC.strings
@@ -1,0 +1,30 @@
+/* Class = "UITableViewSection"; footerTitle = "If you enter a wrong AppLock passcode, KeePassium will close all databases and clear all master keys from the keychain."; ObjectID = "5Dg-KX-m7a"; Note = "AppLock settings section: what to do when the user enters a wrong AppLock passcode."; */
+"5Dg-KX-m7a.footerTitle" = "Si vous entrez un mauvais code d'accès AppLock, KeePassium fermera toutes les bases de données et effacera toutes les clés maîtresses du trousseau.";
+
+/* Class = "UITableViewSection"; headerTitle = "Wrong Passcode"; ObjectID = "5Dg-KX-m7a"; Note = "AppLock settings section: what to do when the user enters a wrong AppLock passcode."; */
+"5Dg-KX-m7a.headerTitle" = "Code d'accès erroné";
+
+/* Class = "UILabel"; text = "Protect Databases"; ObjectID = "6Pk-35-Fx6"; */
+"6Pk-35-Fx6.text" = "Protéger les bases de données";
+
+/* Class = "UITableViewSection"; footerTitle = "Allows biometric authentication as a quick (but less secure) alternative to AppLock passcode."; ObjectID = "7ae-8I-LiQ"; Note = "AppLock settings section: biometric auth (Touch ID/Face ID)"; */
+"7ae-8I-LiQ.footerTitle" = "Permet l'authentification biométrique en tant qu'alternative rapide (mais moins sécurisée) au code d'accès AppLock.";
+
+/* Class = "UITableViewSection"; headerTitle = "Biometrics"; ObjectID = "7ae-8I-LiQ"; Note = "AppLock settings section: biometric auth (Touch ID/Face ID)"; */
+"7ae-8I-LiQ.headerTitle" = "Biométriques";
+
+/* Class = "UITableViewSection"; footerTitle = "Protect KeePassium from unauthorized access."; ObjectID = "aBx-Ee-bMk"; Note = "Explanation for the `Enable AppLock` option."; */
+"aBx-Ee-bMk.footerTitle" = "Protéger KeePassium contre les accès non autorisés.";
+
+/* Class = "UILabel"; text = "Timeout"; ObjectID = "Ef4-Jw-xeO"; Note = "Title for App Lock Timeout setting"; */
+"Ef4-Jw-xeO.text" = "Expiration";
+
+/* Class = "UILabel"; text = "Enable AppLock"; ObjectID = "IS1-Lb-MFy"; */
+"IS1-Lb-MFy.text" = "Activer le verrou d'applications";
+
+/* Class = "UITableViewSection"; footerTitle = "The app will automatically lock up after this time."; ObjectID = "m50-fl-4tu"; */
+"m50-fl-4tu.footerTitle" = "L'application se verrouille automatiquement après ce délai.";
+
+/* Class = "UITableViewController"; title = "App Protection"; ObjectID = "U5m-je-MhO"; */
+"U5m-je-MhO.title" = "Protection des applications";
+

--- a/KeePassium/settings/appLock/fr.lproj/SettingsAppTimeoutVC.strings
+++ b/KeePassium/settings/appLock/fr.lproj/SettingsAppTimeoutVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UITableViewController"; title = "App Lock Timeout"; ObjectID = "5MH-wG-EYd"; */
+"5MH-wG-EYd.title" = "Délai de verrouillage de l'application";
+

--- a/KeePassium/settings/autoFill/fr.lproj/SettingsAutoFillVC.strings
+++ b/KeePassium/settings/autoFill/fr.lproj/SettingsAutoFillVC.strings
@@ -1,0 +1,30 @@
+/* Class = "UILabel"; text = "Tap \"Passwords & Accounts\""; ObjectID = "7SF-2E-uTg"; Note = "Step 2. Must match system's translation."; */
+"7SF-2E-uTg.text" = "2. Appuyez sur \"Mots de passe & comptes\"";
+
+/* Class = "UILabel"; text = "Select \"KeePassium\""; ObjectID = "caI-eV-WlU"; */
+"caI-eV-WlU.text" = "Sélectionnez \"KeePassium\"";
+
+/* Class = "UITableViewController"; title = "AutoFill"; ObjectID = "ei6-22-NXN"; */
+"ei6-22-NXN.title" = "Remplissage automatique";
+
+/* Class = "UILabel"; text = "Copy OTP to clipboard"; ObjectID = "go1-Nt-isQ"; Note = "Title of an option: copy one-time password to clipboard when using AutoFill"; */
+"go1-Nt-isQ.text" = "Copier OTP dans le presse-papiers";
+
+/* Class = "UILabel"; text = "Open device settings"; ObjectID = "K3a-Mc-VCg"; Note = "Step 1"; */
+"K3a-Mc-VCg.text" = "Ouvrir les paramètres de l’appareil";
+
+/* Class = "UITableViewSection"; headerTitle = "Initial Setup"; ObjectID = "r0b-qe-g8J"; */
+"r0b-qe-g8J.headerTitle" = "Configuration initiale";
+
+/* Class = "UILabel"; text = "Tap \"AutoFill Passwords\""; ObjectID = "UzV-Ht-rGx"; Note = "Step 3. Must match system's translation."; */
+"UzV-Ht-rGx.text" = "Tapez sur \"Remplissage automatique des mots de passe\"";
+
+/* Class = "UILabel"; text = "Turn on \"AutoFill Passwords\""; ObjectID = "X2u-c9-gwU"; */
+"X2u-c9-gwU.text" = "Activer \"Remplissage automatique des mots de passe\"";
+
+/* Class = "UITableViewSection"; footerTitle = "When AutoFill inserts the username and password, it can also copy the one-time password (OTP) for you."; ObjectID = "XYL-1l-Jx6"; */
+"XYL-1l-Jx6.footerTitle" = "Lorsque le remplissage automatique insère le nom d'utilisateur et le mot de passe, il peut également copier le mot de passe unique (OTP) pour vous.";
+
+/* Class = "UITableViewSection"; headerTitle = "One-time passwords"; ObjectID = "XYL-1l-Jx6"; */
+"XYL-1l-Jx6.headerTitle" = "Mot de passe à usage unique (OTP)";
+

--- a/KeePassium/settings/backup/fr.lproj/SettingsBackupTimeoutPickerVC.strings
+++ b/KeePassium/settings/backup/fr.lproj/SettingsBackupTimeoutPickerVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UITableViewController"; title = "Keep Backup Files"; ObjectID = "atf-ra-KMC"; Note = "Dialog for selecting the duration of keeping the backup copies."; */
+"atf-ra-KMC.title" = "Garder les fichiers de sauvegarde";
+

--- a/KeePassium/settings/backup/fr.lproj/SettingsBackupVC.strings
+++ b/KeePassium/settings/backup/fr.lproj/SettingsBackupVC.strings
@@ -1,0 +1,24 @@
+/* Class = "UILabel"; text = "Show Backup Files"; ObjectID = "aEK-cJ-9bc"; Note = "Settings option: whether to show backup copies in the list of database files"; */
+"aEK-cJ-9bc.text" = "Afficher les fichiers de sauvegarde";
+
+/* Class = "UITableViewSection"; footerTitle = "KeePassium can automatically delete old backup files to free up some storage space."; ObjectID = "B3L-Dk-Uq3"; Note = "Settings section of the `Keep Backup Files` option"; */
+"B3L-Dk-Uq3.footerTitle" = "KeePassium peut supprimer automatiquement les anciens fichiers de sauvegarde pour libérer de l'espace de stockage.";
+
+/* Class = "UITableViewSection"; headerTitle = "Periodic cleanup"; ObjectID = "B3L-Dk-Uq3"; Note = "Settings section of the `Keep Backup Files` option"; */
+"B3L-Dk-Uq3.headerTitle" = "Nettoyage périodique";
+
+/* Class = "UILabel"; text = "Make Backup Copies"; ObjectID = "BJ7-eQ-JOc"; Note = "Settings option: backup databases before saving them"; */
+"BJ7-eQ-JOc.text" = "Faire des copies de sauvegarde";
+
+/* Class = "UILabel"; text = "Keep Backup Files"; ObjectID = "G42-gR-eKm"; Note = "Settings option: how long to keep backup copies. Example: `Keep Backup Copies: 3 days`"; */
+"G42-gR-eKm.text" = "Garder les fichiers de sauvegarde";
+
+/* Class = "UITableViewSection"; footerTitle = "Before saving a database, KeePassium will automatically make a copy, just in case."; ObjectID = "nBI-OF-9iV"; Note = "Explanation for the `Make Backup Copies` option"; */
+"nBI-OF-9iV.footerTitle" = "Avant de sauvegarder une base de données, KeePassium fera automatiquement une copie, juste au cas où.";
+
+/* Class = "UITableViewController"; title = "Database Backup"; ObjectID = "nSy-3u-0xW"; */
+"nSy-3u-0xW.title" = "Sauvegarde de base de données";
+
+/* Class = "UITableViewSection"; footerTitle = "Backup copies will appear along with the original files."; ObjectID = "XeH-7q-aad"; Note = "Explanation for the `Show Backup Files` option"; */
+"XeH-7q-aad.footerTitle" = "Les copies de sauvegarde apparaîtront avec les fichiers originaux.";
+

--- a/KeePassium/settings/de.lproj/SettingsDataProtectionVC.strings
+++ b/KeePassium/settings/de.lproj/SettingsDataProtectionVC.strings
@@ -32,7 +32,7 @@
 "Mxu-GP-FmN.headerTitle" = "Schlüsseldatei";
 
 /* Class = "UITableViewSection"; footerTitle = "Database timeout closes any opened databases and clears any remembered master keys after some time."; ObjectID = "neJ-eG-TV7"; */
-"neJ-eG-TV7.footerTitle" = "Schließt alle Datenbanken und entfernt alle Schlüssel nach der festgelegten Zeit";
+"neJ-eG-TV7.footerTitle" = "Schließt alle Datenbanken und entfernt alle Schlüssel nach der festgelegten Zeit.";
 
 /* Class = "UITableViewSection"; headerTitle = "Automatic Lock"; ObjectID = "neJ-eG-TV7"; */
 "neJ-eG-TV7.headerTitle" = "Automatisch sperren";

--- a/KeePassium/settings/de.lproj/SettingsVC.strings
+++ b/KeePassium/settings/de.lproj/SettingsVC.strings
@@ -17,7 +17,7 @@
 "c5H-hS-sU3.text" = "KeePassium bewerten";
 
 /* Class = "UITableViewSection"; headerTitle = "Support"; ObjectID = "cBS-jW-dHU"; */
-"cBS-jW-dHU.headerTitle" = "unterstützen";
+"cBS-jW-dHU.headerTitle" = "Unterstützen";
 
 /* Class = "UILabel"; text = "Database Backup"; ObjectID = "coD-Om-Vfm"; Note = "Settings section"; */
 "coD-Om-Vfm.text" = "Datenbank-Backup";

--- a/KeePassium/settings/fr.lproj/SettingsClipboardTimeoutVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsClipboardTimeoutVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UITableViewController"; title = "Clipboard Timeout"; ObjectID = "iJJ-jv-hhP"; Note = "TItle of a list of options, when to delete clipboard content. Alternative title \"Clear Clipboard\""; */
+"iJJ-jv-hhP.title" = "Délai de purge du presse-papiers";
+

--- a/KeePassium/settings/fr.lproj/SettingsDataProtectionVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsDataProtectionVC.strings
@@ -1,0 +1,45 @@
+/* Class = "UIButton"; normalTitle = "Clear Key File Associations"; ObjectID = "3uV-Zs-RRo"; */
+"3uV-Zs-RRo.normalTitle" = "Effacer les associations de fichiers clés";
+
+/* Class = "UIButton"; normalTitle = "Clear Master Keys"; ObjectID = "e1v-nv-Mst"; */
+"e1v-nv-Mst.normalTitle" = "Effacer les clés maîtresses";
+
+/* Class = "UITableViewSection"; footerTitle = "Once you unlock a database, its master key can be stored in device's secure keychain. The next time, KeePassium will use that key so you won't have to type your full master password again. \n\n(Master keys are automatically cleared on database timeout.)"; ObjectID = "Faj-km-pM5"; */
+"Faj-km-pM5.footerTitle" = "Une fois que vous avez déverrouillé une base de données, sa clé principale peut être stockée dans le trousseau sécurisé du périphérique. La prochaine fois, KeePassium utilisera cette clé, de sorte que vous n'aurez plus à taper votre mot de passe maître complet. \n\n(les clés maîtresses sont automatiquement effacées lors de l'expiration de la session de base de données.)";
+
+/* Class = "UITableViewSection"; headerTitle = "Quick Unlock"; ObjectID = "Faj-km-pM5"; */
+"Faj-km-pM5.headerTitle" = "Déverrouillage rapide";
+
+/* Class = "UITableViewSection"; footerTitle = "When you copy anything, KeePassium will automatically clear your clipboard (pasteboard) after some time."; ObjectID = "hnI-Q8-Ixm"; */
+"hnI-Q8-Ixm.footerTitle" = "Lorsque vous copiez du texte depuis une entrée, l'application effacera automatiquement votre presse-papiers après un certain délai.";
+
+/* Class = "UITableViewSection"; headerTitle = "Clipboard"; ObjectID = "hnI-Q8-Ixm"; */
+"hnI-Q8-Ixm.headerTitle" = "Presse-papier";
+
+/* Class = "UILabel"; text = "Remember Master Keys"; ObjectID = "INJ-Cy-Tfo"; */
+"INJ-Cy-Tfo.text" = "Se souvenir des clés maîtresses";
+
+/* Class = "UITableViewController"; title = "Data Protection"; ObjectID = "IZZ-aM-g2i"; */
+"IZZ-aM-g2i.title" = "Protection des données";
+
+/* Class = "UILabel"; text = "Remember Key Files"; ObjectID = "JHl-o7-xHI"; */
+"JHl-o7-xHI.text" = "Se souvenir des fichiers clés";
+
+/* Class = "UITableViewSection"; footerTitle = "Remember and automatically select the last used key file for each database. Clearing the associations does not affect the files."; ObjectID = "Mxu-GP-FmN"; */
+"Mxu-GP-FmN.footerTitle" = "Mémoriser et sélectionner automatiquement le dernier fichier de clé utilisé pour chaque base de données. Effacer les associations n'affecte pas les fichiers.";
+
+/* Class = "UITableViewSection"; headerTitle = "Key Files"; ObjectID = "Mxu-GP-FmN"; */
+"Mxu-GP-FmN.headerTitle" = "Fichiers clés";
+
+/* Class = "UITableViewSection"; footerTitle = "Database timeout closes any opened databases and clears any remembered master keys after some time."; ObjectID = "neJ-eG-TV7"; */
+"neJ-eG-TV7.footerTitle" = "Le délai de réponse de la base de données dépassé, ferme toutes les bases de données ouvertes et efface les clés maîtresses mémorisées après un certain temps.";
+
+/* Class = "UITableViewSection"; headerTitle = "Automatic Lock"; ObjectID = "neJ-eG-TV7"; */
+"neJ-eG-TV7.headerTitle" = "Verrouiller automatiquement";
+
+/* Class = "UILabel"; text = "Clipboard Timeout"; ObjectID = "SSu-Sr-MCg"; */
+"SSu-Sr-MCg.text" = "Délai de purge du presse-papiers";
+
+/* Class = "UILabel"; text = "Database Timeout"; ObjectID = "weX-SZ-IDB"; */
+"weX-SZ-IDB.text" = "Délai de réponse de la base de données";
+

--- a/KeePassium/settings/fr.lproj/SettingsDatabaseTimeoutVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsDatabaseTimeoutVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UITableViewController"; title = "Database Timeout"; ObjectID = "26a-m8-zQP"; Note = "Title of a list of database timeouts, linked to Settings/Data Protection/Database Timeout."; */
+"26a-m8-zQP.title" = "Expiration de la session de base de données";
+

--- a/KeePassium/settings/fr.lproj/SettingsFileSortingVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsFileSortingVC.strings
@@ -1,0 +1,6 @@
+/* Class = "UITableViewController"; title = "File Sorting"; ObjectID = "87L-KA-IeR"; Note = "Settings page"; */
+"87L-KA-IeR.title" = "Tri des fichiers";
+
+/* Class = "UILabel"; text = "Show Backup Files"; ObjectID = "pp5-eX-yPx"; Note = "Settings switch: whether to include backup copies in the file list"; */
+"pp5-eX-yPx.text" = "Afficher les fichiers de sauvegarde";
+

--- a/KeePassium/settings/fr.lproj/SettingsItemListVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsItemListVC.strings
@@ -1,0 +1,3 @@
+/* Class = "UINavigationItem"; title = "List Settings"; ObjectID = "Gyy-12-KPC"; */
+"Gyy-12-KPC.title" = "Paramètres de la liste";
+

--- a/KeePassium/settings/fr.lproj/SettingsVC.strings
+++ b/KeePassium/settings/fr.lproj/SettingsVC.strings
@@ -1,0 +1,72 @@
+/* Class = "UITableViewSection"; footerTitle = "After opening a database, automatically show the search field."; ObjectID = "9Me-8P-nIZ"; */
+"9Me-8P-nIZ.footerTitle" = "Après l'ouverture d'une base de données, afficher automatiquement le champ de recherche.";
+
+/* Class = "UITableViewSection"; headerTitle = "Start"; ObjectID = "9Me-8P-nIZ"; */
+"9Me-8P-nIZ.headerTitle" = "Démarrer";
+
+/* Class = "UITableViewSection"; headerTitle = "Premium"; ObjectID = "A5N-B3-t3t"; */
+"A5N-B3-t3t.headerTitle" = "Premium";
+
+/* Class = "UILabel"; text = "App Protection"; ObjectID = "abS-AH-iFO"; Note = "Settings section: protection of the app from unauthorized access"; */
+"abS-AH-iFO.text" = "Protection des applications";
+
+/* Class = "UINavigationItem"; title = "Settings"; ObjectID = "Bk0-Xf-O7B"; */
+"Bk0-Xf-O7B.title" = "Réglages";
+
+/* Class = "UILabel"; text = "Review KeePassium"; ObjectID = "c5H-hS-sU3"; Note = "Action: write an app review on the App Store"; */
+"c5H-hS-sU3.text" = "Evaluer KeePassium";
+
+/* Class = "UITableViewSection"; headerTitle = "Support"; ObjectID = "cBS-jW-dHU"; */
+"cBS-jW-dHU.headerTitle" = "Assistance technique";
+
+/* Class = "UILabel"; text = "Database Backup"; ObjectID = "coD-Om-Vfm"; Note = "Settings section"; */
+"coD-Om-Vfm.text" = "Sauvegarde de base de données";
+
+/* Class = "UILabel"; text = "About KeePassium"; ObjectID = "DNo-Rs-0EP"; */
+"DNo-Rs-0EP.text" = "À propos de KeePassium";
+
+/* Class = "UILabel"; text = "Master keys, key files"; ObjectID = "FHp-ns-ke9"; Note = "Subtitle/details for `Data Protection`"; */
+"FHp-ns-ke9.text" = "Clés principales, fichiers de clés";
+
+/* Class = "UILabel"; text = "Premium Version"; ObjectID = "HCe-A3-eG6"; Note = "Status shown on premium tier"; */
+"HCe-A3-eG6.text" = "Version Premium";
+
+/* Class = "UITableViewSection"; headerTitle = "Backup"; ObjectID = "HjD-9G-X8p"; */
+"HjD-9G-X8p.headerTitle" = "Sauvegarde";
+
+/* Class = "UITableViewSection"; headerTitle = "Access Control"; ObjectID = "hui-xG-chj"; */
+"hui-xG-chj.headerTitle" = "Contrôle des accès";
+
+/* Class = "UILabel"; text = "Rate KeePassium on the App Store"; ObjectID = "HYe-lP-dCp"; Note = "Subtitle for `Review KeePassium`"; */
+"HYe-lP-dCp.text" = "Evaluez l'application sur «App Store»";
+
+/* Class = "UILabel"; text = "Upgrade to Premium"; ObjectID = "oxG-N8-1ld"; */
+"oxG-N8-1ld.text" = "Passer à la version Premium";
+
+/* Class = "UILabel"; text = "Diagnostic Log"; ObjectID = "PpA-oZ-kr2"; Note = "Action: show diagnostic log"; */
+"PpA-oZ-kr2.text" = "Journal de diagnostic";
+
+/* Class = "UILabel"; text = "For expert troubleshooting"; ObjectID = "qhK-lw-bGy"; Note = "Subtitle for `Diagnostic Log`. Keep it short."; */
+"qhK-lw-bGy.text" = "Résolution de problèmes pour expert";
+
+/* Class = "UILabel"; text = "Contact Us"; ObjectID = "QlM-VS-hle"; Note = "Action"; */
+"QlM-VS-hle.text" = "Contactez-nous";
+
+/* Class = "UILabel"; text = "Suggestions? Problems? Let us know!"; ObjectID = "RNK-fS-Fvx"; Note = "Subtitle for `Contact Us`. Keep it short."; */
+"RNK-fS-Fvx.text" = "Des suggestions ? Des problèmes? Faites-le nous savoir !";
+
+/* Class = "UILabel"; text = "AutoFill Passwords"; ObjectID = "T2Z-oa-zJR"; */
+"T2Z-oa-zJR.text" = "Remplissage automatique des mots de passe";
+
+/* Class = "UILabel"; text = "Data Protection"; ObjectID = "UNl-Hc-Ref"; Note = "Settings section: protection of databases, their keys and data inside them"; */
+"UNl-Hc-Ref.text" = "Protection des données";
+
+/* Class = "UILabel"; text = "Start with Search"; ObjectID = "yuN-Ls-o9d"; */
+"yuN-Ls-o9d.text" = "Commencer avec recherche";
+
+/* Class = "UITableViewSection"; headerTitle = "AutoFill"; ObjectID = "ZFi-ss-fUa"; */
+"ZFi-ss-fUa.headerTitle" = "Remplissage automatique";
+
+/* Class = "UILabel"; text = "Manage Subscriptions"; ObjectID = "zUh-Sn-3ya"; Note = "Action: open AppStore subscription management page"; */
+"zUh-Sn-3ya.text" = "Gérer les abonnements";
+

--- a/KeePassium/util/LString.swift
+++ b/KeePassium/util/LString.swift
@@ -50,6 +50,11 @@ public enum LString {
         value: "Rename",
         comment: "Action/button to rename an item"
     )
+    public static let actionOverwrite = NSLocalizedString(
+        "[Generic] Overwrite",
+        value: "Overwrite",
+        comment: "Action/button to replace/overwrite an item"
+    )
     public static let actionMove = NSLocalizedString(
         "[Generic] Move",
         value: "Move",
@@ -140,6 +145,11 @@ public enum LString {
         "[File/PermissionDenied] Try to remove the file from the app, then add it again.",
         value: "Try to remove the file from the app, then add it again.",
         comment: "A suggestion shown after specific file errors (either databases or key files)."
+    )
+    public static let fileAlreadyExists = NSLocalizedString(
+        "[Generic/File/title] File already exists",
+        value: "File already exists",
+        comment: "Message shown when trying to copy into an existing file."
     )
     
 

--- a/KeePassiumLib/KeePassiumLib.xcodeproj/project.pbxproj
+++ b/KeePassiumLib/KeePassiumLib.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		7502613D243E970000C47F4F /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7505E8CA2236C93300E5202E /* TOTPGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOTPGenerator.swift; sourceTree = "<group>"; };
 		7505E8CE2236ED6E00E5202E /* Base32.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Base32.swift; sourceTree = "<group>"; };
 		7505E8D02236FA0F00E5202E /* StringExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
@@ -685,6 +686,7 @@
 				cs,
 				sv,
 				es,
+				fr,
 			);
 			mainGroup = 75D0C7602174AF1F00C64C93;
 			productRefGroup = 75D0C76B2174AF1F00C64C93 /* Products */;
@@ -859,6 +861,7 @@
 				75FDEF1D233ABE7800F17C26 /* cs */,
 				75FDEF49233ABED700F17C26 /* sv */,
 				75AC35BB23549D6C00B60614 /* es */,
+				7502613D243E970000C47F4F /* fr */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/KeePassiumLib/KeePassiumLib/DatabaseManager.swift
+++ b/KeePassiumLib/KeePassiumLib/DatabaseManager.swift
@@ -224,11 +224,14 @@ public class DatabaseManager {
                     comment: "Error message"))
                 return
             }
-            Diag.debug("New composite key created successfully")
+            let staticComponents = keyHelper.combineComponents(
+                passwordData: passwordData, 
+                keyFileData: keyFileData    
+            )
             let compositeKey = CompositeKey(
-                passwordData: passwordData,
-                keyFileData: keyFileData,
+                staticComponents: staticComponents,
                 challengeHandler: challengeHandler)
+            Diag.debug("New composite key created successfully")
             successHandler(compositeKey)
         }
         

--- a/KeePassiumLib/KeePassiumLib/db/DatabaseItem.swift
+++ b/KeePassiumLib/KeePassiumLib/db/DatabaseItem.swift
@@ -8,6 +8,11 @@
 
 
 open class DatabaseItem {
+    public enum TouchMode {
+        case accessed
+        case modified
+    }
+    
     public weak var parent: Group?
     
     public func isAncestor(of item: DatabaseItem) -> Bool {
@@ -19,5 +24,9 @@ open class DatabaseItem {
             parent = parent?.parent
         }
         return false
+    }
+    
+    public func touch(_ mode: TouchMode, updateParents: Bool = true) {
+        fatalError("Pure abstract method")
     }
 }

--- a/KeePassiumLib/KeePassiumLib/db/Entry.swift
+++ b/KeePassiumLib/KeePassiumLib/db/Entry.swift
@@ -224,12 +224,14 @@ public class Entry: DatabaseItem, Eraseable {
         fatalError("Pure virtual method")
     }
     
-    public func accessed() {
+    override public func touch(_ mode: DatabaseItem.TouchMode, updateParents: Bool = true) {
         lastAccessTime = Date.now
-    }
-    public func modified() {
-        accessed()
-        lastModificationTime = Date.now
+        if mode == .modified {
+            lastModificationTime = Date.now
+        }
+        if updateParents {
+            parent?.touch(mode, updateParents: true)
+        }
     }
     
     public func deleteWithoutBackup() {

--- a/KeePassiumLib/KeePassiumLib/db/Group.swift
+++ b/KeePassiumLib/KeePassiumLib/db/Group.swift
@@ -194,12 +194,14 @@ public class Group: DatabaseItem, Eraseable {
         fatalError("Pure virtual method")
     }
     
-    public func accessed() {
+    override public func touch(_ mode: DatabaseItem.TouchMode, updateParents: Bool = true) {
         lastAccessTime = Date.now
-    }
-    public func modified() {
-        accessed()
-        lastModificationTime = Date.now
+        if mode == .modified {
+            lastModificationTime = Date.now
+        }
+        if updateParents {
+            parent?.touch(mode, updateParents: true)
+        }
     }
 
     public func collectAllChildren(groups: inout Array<Group>, entries: inout Array<Entry>) {

--- a/KeePassiumLib/KeePassiumLib/db/kp1/Database1.swift
+++ b/KeePassiumLib/KeePassiumLib/db/kp1/Database1.swift
@@ -426,7 +426,7 @@ public class Database1: Database {
         
         subEntries.forEach { (entry) in
             entry.move(to: backupGroup)
-            entry.accessed()
+            entry.touch(.accessed, updateParents: false)
         }
         Diag.debug("Delete group OK")
     }
@@ -442,8 +442,8 @@ public class Database1: Database {
             return
         }
         
-        entry.accessed()
         entry.move(to: backupGroup)
+        entry.touch(.accessed, updateParents: false)
         Diag.info("Delete entry OK")
     }
     

--- a/KeePassiumLib/KeePassiumLib/db/kp2/Entry2.swift
+++ b/KeePassiumLib/KeePassiumLib/db/kp2/Entry2.swift
@@ -350,9 +350,14 @@ public class Entry2: Entry {
         maintainHistorySize()
     }
 
-    override public func accessed() {
-        super.accessed()
+    override public func touch(_ mode: DatabaseItem.TouchMode, updateParents: Bool = true) {
         usageCount += 1
+        super.touch(mode, updateParents: updateParents)
+    }
+    
+    override public func move(to newGroup: Group) {
+        super.move(to: newGroup)
+        locationChangedTime = Date.now
     }
     
     func load(

--- a/KeePassiumLib/KeePassiumLib/db/kp2/Group2.swift
+++ b/KeePassiumLib/KeePassiumLib/db/kp2/Group2.swift
@@ -93,11 +93,16 @@ public class Group2: Group {
         return newGroup
     }
     
-    override public func accessed() {
-        super.accessed()
+    override public func touch(_ mode: DatabaseItem.TouchMode, updateParents: Bool = true) {
         usageCount += 1
+        super.touch(mode, updateParents: updateParents)
     }
 
+    override public func move(to newGroup: Group) {
+        super.move(to: newGroup)
+        self.locationChangedTime = Date.now
+    }
+    
     func load(
         xml: AEXMLElement,
         streamCipher: StreamCipher,

--- a/KeePassiumLib/KeePassiumLib/db/kp2/Meta2.swift
+++ b/KeePassiumLib/KeePassiumLib/db/kp2/Meta2.swift
@@ -89,9 +89,9 @@ final class Meta2: Eraseable {
     private(set) var defaultUserNameChangedTime: Date
     private(set) var maintenanceHistoryDays: UInt32
     private(set) var colorString: String
-    internal var masterKeyChangedTime: Date
-    private(set) var masterKeyChangeRec: Int64
-    private(set) var masterKeyChangeForce: Int64
+    internal var masterKeyChangedTime: Date 
+    private(set) var masterKeyChangeRec: Int64 
+    private(set) var masterKeyChangeForce: Int64 
     private(set) var memoryProtection: MemoryProtection
     private(set) var isRecycleBinEnabled: Bool
     private(set) var recycleBinGroupUUID: UUID

--- a/KeePassiumLib/KeePassiumLib/files/FileKeeper.swift
+++ b/KeePassiumLib/KeePassiumLib/files/FileKeeper.swift
@@ -42,9 +42,26 @@ public enum FileKeeperError: LocalizedError {
     }
 }
 
+public protocol FileKeeperDelegate: class {
+    
+    func shouldResolveImportConflict(
+        target: URL,
+        handler: @escaping (FileKeeper.ConflictResolution) -> Void
+    )
+}
+
 public class FileKeeper {
     public static let shared = FileKeeper()
     
+    public weak var delegate: FileKeeperDelegate?
+    
+    public enum ConflictResolution {
+        case ask
+        case abort
+        case rename
+        case overwrite
+    }
+
     private enum UserDefaultsKey {
         static var mainAppPrefix: String {
             if BusinessModel.type == .prepaid {
@@ -81,9 +98,9 @@ public class FileKeeper {
     private var openMode: OpenMode = .openInPlace
     private var pendingOperationGroup = DispatchGroup()
     
-    private let docDirURL: URL
-    private let backupDirURL: URL
-    private let inboxDirURL: URL
+    fileprivate let docDirURL: URL
+    fileprivate let backupDirURL: URL
+    fileprivate let inboxDirURL: URL
     
     public var hasPendingFileOperations: Bool {
         return urlToOpen != nil
@@ -215,14 +232,8 @@ public class FileKeeper {
         Diag.debug("Will trash local file [fileType: \(fileType)]")
         do {
             let url = try urlRef.resolve()
-            do {
-                try FileManager.default.trashItem(at: url, resultingItemURL: nil)
-                Diag.info("Local file moved to trash")
-            } catch {
-                Diag.warning("Failed to trash file, will delete instead [message: '\(error.localizedDescription)']")
-                try FileManager.default.removeItem(at: url)
-                Diag.info("Local file permanently deleted")
-            }
+            try FileManager.default.removeItem(at: url)
+            Diag.info("Local file deleted")
             FileKeeperNotifier.notifyFileRemoved(urlRef: urlRef, fileType: fileType)
         } catch {
             if ignoreErrors {
@@ -518,6 +529,7 @@ public class FileKeeper {
         )
     }
     
+    
     private func importFile(
         url sourceURL: URL,
         success successHandler: ((URL) -> Void)?,
@@ -535,38 +547,114 @@ public class FileKeeper {
         
         Diag.debug("Will import a file")
         let doc = FileDocument(fileURL: sourceURL)
-        doc.open(successHandler: {
-            do {
-                try doc.data.write(to: targetURL, options: [.withoutOverwriting])
-                Diag.info("External file copied successfully")
-                successHandler?(targetURL)
-            } catch {
-                Diag.error("Failed to save external file [message: \(error.localizedDescription)]")
+        doc.open(
+            successHandler: { 
+                self.saveDataWithConflictResolution(
+                    doc.data,
+                    to: targetURL,
+                    conflictResolution: .ask,
+                    success: successHandler,
+                    error: errorHandler)
+            },
+            errorHandler: { error in 
+                Diag.error("Failed to import external file [message: \(error.localizedDescription)]")
                 let importError = FileKeeperError.importError(reason: error.localizedDescription)
                 errorHandler?(importError)
+                self.clearInbox()
             }
-            self.clearInbox()
-        }, errorHandler: { error in
-            Diag.error("Failed to import external file [message: \(error.localizedDescription)]")
-            let importError = FileKeeperError.importError(reason: error.localizedDescription)
-            errorHandler?(importError)
-            self.clearInbox()
-        })
+        )
+    }
+    
+    private func saveDataWithConflictResolution(
+        _ data: ByteArray,
+        to targetURL: URL,
+        conflictResolution: FileKeeper.ConflictResolution,
+        success successHandler: ((URL) -> Void)?,
+        error errorHandler: ((FileKeeperError)->Void)?)
+    {
+        let hasConflict = FileManager.default.fileExists(atPath: targetURL.path)
+        guard hasConflict else {
+            writeToFile(data, to: targetURL, success: successHandler, error: errorHandler)
+            clearInbox()
+            return
+        }
+        
+        switch conflictResolution {
+        case .ask:
+            assert(delegate != nil)
+            delegate?.shouldResolveImportConflict(
+                target: targetURL,
+                handler: { (resolution) in 
+                    Diag.info("Conflict resolution: \(resolution)")
+                    self.saveDataWithConflictResolution(
+                        data,
+                        to: targetURL,
+                        conflictResolution: resolution,
+                        success: successHandler,
+                        error: errorHandler)
+                }
+            )
+        case .abort:
+            clearInbox()
+            successHandler?(targetURL)
+        case .rename:
+            let newURL = makeUniqueFileName(targetURL)
+            writeToFile(data, to: newURL, success: successHandler, error: errorHandler)
+            clearInbox()
+            successHandler?(newURL)
+        case .overwrite:
+            writeToFile(data, to: targetURL, success: successHandler, error: errorHandler)
+            clearInbox()
+            successHandler?(targetURL)
+        }
     }
     
     
+    private func makeUniqueFileName(_ url: URL) -> URL {
+        let fileManager = FileManager.default
+
+        let path = url.deletingLastPathComponent()
+        let fileNameNoExt = url.deletingPathExtension().lastPathComponent
+        let fileExt = url.pathExtension
+        
+        var fileName = url.lastPathComponent
+        var index = 1
+        while fileManager.fileExists(atPath: path.appendingPathComponent(fileName).path) {
+            fileName = String(format: "%@ (%d).%@", fileNameNoExt, index, fileExt)
+            index += 1
+        }
+        return path.appendingPathComponent(fileName)
+    }
+    
+    private func writeToFile(
+        _ bytes: ByteArray,
+        to targetURL: URL,
+        success successHandler: ((URL) -> Void)?,
+        error errorHandler: ((FileKeeperError)->Void)?)
+    {
+        do {
+            try bytes.write(to: targetURL, options: [.atomicWrite])
+            Diag.debug("File imported successfully")
+            clearInbox()
+            successHandler?(targetURL)
+        } catch {
+            Diag.error("Failed to save external file [message: \(error.localizedDescription)]")
+            let importError = FileKeeperError.importError(reason: error.localizedDescription)
+            errorHandler?(importError)
+        }
+    }
+    
     private func clearInbox() {
-        guard let inboxFiles = try? FileManager.default.contentsOfDirectory(
+        let fileManager = FileManager()
+        let inboxFiles = try? fileManager.contentsOfDirectory(
             at: inboxDirURL,
             includingPropertiesForKeys: nil,
             options: [])
-        else {
-            return
-        }
-        for url in inboxFiles {
-            try? FileManager.default.removeItem(at: url) 
+        inboxFiles?.forEach {
+            try? fileManager.removeItem(at: $0) 
         }
     }
+    
     
     func makeBackup(nameTemplate: String, contents: ByteArray) {
         guard !contents.isEmpty else {

--- a/KeePassiumLib/KeePassiumLib/files/FileType.swift
+++ b/KeePassiumLib/KeePassiumLib/files/FileType.swift
@@ -37,7 +37,7 @@ public enum FileType {
     case keyFile
 
     init(for url: URL) {
-        if FileType.DatabaseExtensions.all.contains(url.pathExtension) {
+        if FileType.DatabaseExtensions.all.contains(url.pathExtension.localizedLowercase) {
             self = .database
         } else {
             self = .keyFile
@@ -45,6 +45,6 @@ public enum FileType {
     }
 
     public static func isDatabaseFile(url: URL) -> Bool {
-        return DatabaseExtensions.all.contains(url.pathExtension)
+        return DatabaseExtensions.all.contains(url.pathExtension.localizedLowercase)
     }
 }

--- a/KeePassiumLib/KeePassiumLib/fr.lproj/Localizable.strings
+++ b/KeePassiumLib/KeePassiumLib/fr.lproj/Localizable.strings
@@ -1,0 +1,357 @@
+/* Type of keyboard to show for App Lock passcode: letters and digits. */
+"[AppLock/Passcode/KeyboardType/title] Alphanumeric" = "Alphanumérique";
+
+/* Type of keyboard to show for App Lock passcode: digits only (PIN code). */
+"[AppLock/Passcode/KeyboardType/title] Numeric" = "Numérique";
+
+/* Progress status */
+"[Cipher/Progress] Decrypting" = "Déchiffrement";
+
+/* Progress status */
+"[Cipher/Progress] Encrypting" = "Chiffrement";
+
+/* Error message about AES cipher. [errorCode: Int] */
+"[CryptoError] AES decryption error (code %d)" = "Erreur de déchiffrement AES (code %d)";
+
+/* Error message about AES cipher. [errorCode: Int] */
+"[CryptoError] AES encryption error (code %d)" = "Erreur de chiffrement AES (code %d)";
+
+/* Error message about AES cipher. [errorCode: Int] */
+"[CryptoError] AES initialization error (code %d)" = "Erreur d'initialisation AES (code %d)";
+
+/* Error message about Argon2 hashing function. [errorCode: Int] */
+"[CryptoError] Argon2 hashing error (code %d)" = "Erreur de hachage Argon2 (code %d)";
+
+/* Error message about PKCS7 padding. [errorCode: Int] */
+"[CryptoError] Invalid data padding (code %d). File corrupt?" = "Remplissage de données invalide (code %d). Fichier corrompu ?";
+
+/* Error message about key derivation function (KDF) parameters. [kdfName: String, paramName: String] */
+"[CryptoError] Invalid KDF parameter: %@ - %@. File corrupt?" = "Paramètre KDF invalide : %1$@ - %2$@. Fichier corrompu ?";
+
+/* Error message about random number generator. [errorCode: Int] */
+"[CryptoError] Random number generator error (code %d)" = "Erreur du générateur de nombre aléatoire (code %d)";
+
+/* Error message about Twofish cipher. [errorCode: Int] */
+"[CryptoError] Twofish cipher error (code %d)" = "Erreur Twofish cipher (code %d)";
+
+/* Error message */
+"[Database/Load/Error] Cannot find database file" = "KeePassiumLib/en. lproj/Localizable. strings\n[Base de données/Chargement/Erreur] Le fichier de base de données n'a pas été trouvé\nMessage d'erreur:\nFichier: KeePassiumLib. xliff";
+
+/* Error message */
+"[Database/Load/Error] Cannot find key file" = "KeePassiumLib/en. lproj/Localizable. strings\n[Base de données/Chargement/Erreur] Impossible de trouver le fichier clé\nMessage d'erreur:\nFichier: KeePassiumLib. xliff";
+
+/* Error message */
+"[Database/Load/Error] Cannot open database file" = "KeePassiumLib/en. lproj/Localizable. strings\n[Base de données/Chargement/Erreur] Impossible d'ouvrir le fichierr de base de données\nMessage d'erreur\nFichier: KeePassiumLib. xliff";
+
+/* Error message */
+"[Database/Load/Error] Cannot open key file" = "Impossible d'ouvrir le fichier de clé";
+
+/* Error shown when both master password and key file are empty */
+"[Database/Load/Error] Please provide at least a password or a key file" = "Veuillez fournir au moins un mot de passe ou un fichier clé";
+
+/* Error message */
+"[Database/Load/Error] Unrecognized database format" = "Format de la base de données non reconnu";
+
+/* Progress status: finished loading database */
+"[Database/Progress] Done" = "Fait";
+
+/* Progress bar status */
+"[Database/Progress] Loading database file..." = "Chargement de la bases de données...";
+
+/* Progress status */
+"[Database/Progress] Loading key file..." = "Chargement du fichier de clé...";
+
+/* Error message */
+"[Database/Unlock/Error] Failed to open key file" = "Impossible d'ouvrir le fichier de clé";
+
+/* Error message */
+"[Database/Unlock/Error] Password and key file are both empty." = "Le mot de passe et le fichier de clé sont tous deux vides.";
+
+/* Error message */
+"[Database1/FormatError] Database file is corrupted." = "Le fichier de base de données est corrompu.";
+
+/* Error message [fieldName: String] */
+"[Database1/FormatError] Error parsing field %@. Corrupted database file?" = "Erreur lors de l'analyse du champ %@. Fichier de base de données corrompu ?";
+
+/* Error message */
+"[Database1/FormatError] Found an entry outside any group. Corrupted DB file?" = "Une entrée a été trouvée en dehors d'un groupe. Fichier de base de données corrompu ?";
+
+/* Error message */
+"[Database1/FormatError] Unexpected end of file. Corrupted database file?" = "Fin de fichier inattendue. Fichier de base de données corrompu?";
+
+/* Error message when reading database header */
+"[Database1/Header1/Error] Header reading error. DB file corrupt?" = "Erreur de lecture de l'en-tête. Fichier de la base de données corrompu?";
+
+/* Error message. [flagsHexString: String] */
+"[Database1/Header1/Error] Unsupported cipher. (Code: %@)" = "Chiffrement non pris en charge. (Code : %@)";
+
+/* Error message when opening a database. [version: String] */
+"[Database1/Header1/Error] Unsupported database format version: %@." = "Version du format de base de données non prise en charge : %@.";
+
+/* Error message when opening a database */
+"[Database1/Header1/Error] Wrong file signature. Not a KeePass database?" = "Mauvaise signature de fichier. Pas une base de données KeePass ?";
+
+/* Status message: collecting database items into a single package */
+"[Database1/Progress] Packing the content" = "Emballer le contenu";
+
+/* Status message: processing the content of a database */
+"[Database1/Progress] Parsing content" = "Analyse du contenu";
+
+/* Name of a group which contains deleted entries */
+"[Database2/backupGroupName] Recycle Bin" = "Corbeille";
+
+/* Error message. Parsing refers to the analysis/understanding of file content. [reason: String] */
+"[Database2/FormatError] Cannot parse database. %@" = "Impossible d'analyser la base de données. %@";
+
+/* Error message [blockIndex: Int] */
+"[Database2/FormatError] Corrupted database file (block %d has negative size)" = "Fichier de base de données corrompu (le bloc %d a une taille négative)";
+
+/* Error message: hash(checksum) of a data block is wrong. [blockIndex: Int] */
+"[Database2/FormatError] Corrupted database file (hash mismatch in block %d)" = "Fichier de base de données corrompu (hash incompatible dans le bloc %d)";
+
+/* Error message: HMAC value (kind of checksum) of a data block is wrong. [blockIndex: Int] */
+"[Database2/FormatError] Corrupted database file (HMAC mismatch in block %d)" = "Fichier de base de données corrompu (HMAC incompatible avec le bloc %d)";
+
+/* Error message about Gzip compression algorithm. [reason: String] */
+"[Database2/FormatError] Gzip error: %@" = "Erreur Gzip : %@";
+
+/* Error message: wrong ID of a data block */
+"[Database2/FormatError] Unexpected block ID." = "ID de bloc inattendu.";
+
+/* Error message */
+"[Database2/FormatError] Unexpected end of file. Corrupted file?" = "Fin de fichier inattendue. Fichier corrompu?";
+
+/* Error message when saving a database. [reason: String] */
+"[Database2/Header2/Error] Failed to uncompress attachment data: %@" = "Impossible de décompresser les données de pièce jointe : %@";
+
+/* Error message, with the name of problematic field. [fieldName: String] */
+"[Database2/Header2/Error] Header field %@ is corrupted." = "Le champ d'en-tête %@ est corrompu.";
+
+/* Error message */
+"[Database2/Header2/Error] Header hash mismatch. DB file corrupt?" = "Incompatibilité de hachage de l'en-tête. Fichier de base corrompu ?";
+
+/* Error message. HMAC = https://en.wikipedia.org/wiki/HMAC */
+"[Database2/Header2/Error] Header HMAC mismatch. DB file corrupt?" = "Incompatibilité HMAC de l'en-tête. Fichier de la base de données corrompu ?";
+
+/* Error message when reading database header */
+"[Database2/Header2/Error] Header reading error. DB file corrupt?" = "Erreur de lecture de l'en-tête. Fichier de la base de données corrompu?";
+
+/* Error message when opening a database */
+"[Database2/Header2/Error] Unknown compression algorithm." = "Algorithme de compression inconnu.";
+
+/* Error message. [uuidHexString: String] */
+"[Database2/Header2/Error] Unsupported data cipher: %@" = "Chiffrement de données non pris en charge : %@";
+
+/* Error message when opening a database. [version: String] */
+"[Database2/Header2/Error] Unsupported database format version: %@." = "Version du format de base de données non prise en charge : %@.";
+
+/* Error message when opening a database. [id: UInt32] */
+"[Database2/Header2/Error] Unsupported inner stream cipher (ID %d)" = "Chiffrement de flux interne non pris en charge (ID %d)";
+
+/* Error message about Key Derivation Function. [uuidString: String] */
+"[Database2/Header2/Error] Unsupported KDF: %@" = "KDF non pris en charge : %@";
+
+/* Error message when opening a database */
+"[Database2/Header2/Error] Wrong file signature. Not a KeePass database?" = "Mauvaise signature de fichier. Pas une base de données KeePass ?";
+
+/* Error message about Gzip compression algorithm. [errorMessage: String] */
+"[Database2/Loading/Error] Error unpacking database: %@" = "Erreur lors de la décompression de la base de données : %@";
+
+/* A warning about missing attachments after loading the database. [lastUsedAppName: String, attachmentNames: String] */
+"[Database2/Loading/Warning/missingBinaries]" = "Les pièces jointes de certaines entrées ont des données manquante. Ceci est un signe de corruption de la base de données, probablement par la dernière application utilisée (%1$@). KeePassium conservera les pièces jointes vides, mais ne pourra pas les restaurer. Vous devez restaurer votre base de données à partir d'une copie de sauvegarde. \n\nPièces jointes manquantes : %2$@";
+
+/* A warning about nameless attachments, shown after loading the database. [listOfEntryNames: String] */
+"[Database2/Loading/Warning/namelessAttachments]" = "Certaines entrées ont des pièces jointes sans nom. Ceci est un signe d'une base de données ayant été corrompue.\n\n Veuillez consulter les fichiers joints dans les entrées suivantes (et leur historique):\n%@";
+
+/* A warning about misformatted custom fields after loading the database. [entryPaths: String] */
+"[Database2/Loading/Warning/namelessCustomFields]" = "Certaines entrées ont des champs personnalisés avec des noms vides. Cela peut être un signe de corruption de données. Veuillez vérifier ces entrées :\n\n%@";
+
+/* A warning about unused attachments after loading the database. [lastUsedAppName: String] */
+"[Database2/Loading/Warning/unusedAttachments]" = "La base de données contient des pièces jointes qui ne sont utilisées dans aucune entrée. Très probablement, ils ont été oubliés par la dernière application (%@). Cependant, cela peut également être un signe de corruption des données. \nVeuillez vous assurer d'avoir une sauvegarde de votre base de données avant de changer quoi que ce soit.";
+
+/* Progress bar status */
+"[Database2/Progress] Loading database" = "Chargement de la bases de données";
+
+/* Progress bar status */
+"[Database2/Progress] Reading database content" = "Lecture du contenu de la base de données";
+
+/* Progress bar status */
+"[Database2/Progress] Writing encrypted blocks" = "Écriture de blocs chiffrés";
+
+/* Error message while saving a database. [errorDescription: String] */
+"[Database2/Saving/Error] Data compression error: %@" = "Erreur de compression de données : %@";
+
+/* Error message while saving a database. [errorDescription: String] */
+"[Database2/Saving/Error] Encryption error: %@" = "Erreur de chiffrement : %@";
+
+/* Error message about XML parsing. [value: String, tag: String] */
+"[Database2/Xml2/ParsingError] Malformed value '%@' in %@" = "Valeur '%1$@' malformée dans %2$@";
+
+/* Error message about XML parsing. [tag: String] */
+"[Database2/Xml2/ParsingError] Nil value in %@" = "Valeur Nulle dans %@";
+
+/* Error message about XML parsing */
+"[Database2/Xml2/ParsingError] Not a KeePass XML" = "Pas un XML KeePass";
+
+/* Error message about XML parsing. [actualTag: String] */
+"[Database2/Xml2/ParsingError] Unexpected tag '%@'" = "Balise inattendue '%@'";
+
+/* Error message about XML parsing. [actualTag: String, expectedTag: String] */
+"[Database2/Xml2/ParsingError] Unexpected tag '%@' (instead of '%@')" = "Balise inattendue '%1$@' (au lieu de '%2$@')";
+
+/* Generic error while parsing XML. [errorDetails: String] */
+"[Database2/Xml2/ParsingError] XML error: %@" = "Erreur XML : %@";
+
+/* Error message while opening a database */
+"[DatabaseError] Cannot open database" = "Impossible d'ouvrir la base de données";
+
+/* Error message while saving a database */
+"[DatabaseError] Cannot save database" = "Impossible de sauvegarder la base de données";
+
+/* Error message: user provided a wrong master key for decryption. */
+"[DatabaseError] Invalid password or key file" = "Mot de passe ou clé de fichier incorrect";
+
+/* A very generic error message */
+"[FileDocument] Unexpected file error, please contact us." = "Une erreur inattendue est survenue, veuillez contacter le support technique.";
+
+/* Error message [reason: String] */
+"[FileKeeper] Failed to delete file. Reason: %@" = "Échec de la suppression du fichier. Raison : %@";
+
+/* Error message [reason: String] */
+"[FileKeeper] Failed to import file. Reason: %@" = "Échec de l'import du fichier. Raison : %@";
+
+/* Error message [reason: String] */
+"[FileKeeper] Failed to open file. Reason: %@" = "Échec de l'ouverture du fichier. Raison : %@";
+
+/* Error message: tried to import URL which does not point to a file */
+"[FileKeeper] Not a file URL" = "Pas une URL de fichier";
+
+/* A sorting option for a list of files, by file creation date. Example: 'Sort Order: Creation Date (Oldest First)' */
+"[FilesSortOrder/longTitle] Creation Date (Oldest First)" = "Date de création (plus ancien en premier)";
+
+/* A sorting option for a list of files, by file creation date. Example: 'Sort Order: Creation Date (Recent First)' */
+"[FilesSortOrder/longTitle] Creation Date (Recent First)" = "Date de création (Récent en premier)";
+
+/* A sorting option for a list of files, by file's last modification date. Example: 'Sort Order: Modification Date (Oldest First)' */
+"[FilesSortOrder/longTitle] Modification Date (Oldest First)" = "Date de modification (plus ancien en premier)";
+
+/* A sorting option for a list of files, by file's last modification date. Example: 'Sort Order: Modification Date (Recent First)' */
+"[FilesSortOrder/longTitle] Modification Date (Recent First)" = "Date de création (Récent en premier)";
+
+/* A sorting option for a list of files, by file name. Example: 'Sort Order: Name (A..Z)' */
+"[FilesSortOrder/longTitle] Name (A..Z)" = "Nom (A..Z)";
+
+/* A sorting option for a list of files, by file name. Example: 'Sort Order: Name (Z..A)' */
+"[FilesSortOrder/longTitle] Name (Z..A)" = "Nom (Z..A)";
+
+/* A sorting option for a list of files. Example: 'Sort Order: No Sorting' */
+"[FilesSortOrder/longTitle] No Sorting" = "Aucun tri";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Creation Date (New..Old)' */
+"[GroupSortOrder/longTitle] By Creation Date (New..Old)" = "Par Date de Création (Nouveau..Ancien)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Creation Date (Old..New)' */
+"[GroupSortOrder/longTitle] By Creation Date (Old..New)" = "Par Date de Création (Ancien..Nouveau)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Modification Date (New..Old)' */
+"[GroupSortOrder/longTitle] By Modification Date (New..Old)" = "Par Date de Modification (Nouveau..Ancien)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Modification Date (Old..New)' */
+"[GroupSortOrder/longTitle] By Modification Date (Old..New)" = "Par Date de Modification (Old..Nouveau)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Title (A..Z)' */
+"[GroupSortOrder/longTitle] By Title (A..Z)" = "Par titre (A..Z)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: By Title (Z..A)' */
+"[GroupSortOrder/longTitle] By Title (Z..A)" = "Par titre (Z..A)";
+
+/* An option in Group Viewer settings. Example: 'Sort Order: No Sorting' */
+"[GroupSortOrder/longTitle] No Sorting" = "Aucun tri";
+
+/* Status message: processing of the master key is in progress */
+"[KDF/Progress] Processing the master key" = "Traitement de la clé principale";
+
+/* Generic error message about system keychain. [errorCode: Int] */
+"[KeychainError/generic] Keychain error (code %d) " = "Erreur de trousseau (code %d) ";
+
+/* Error message about system keychain. */
+"[KeychainError/unexpectedFormat] Keychain error: unexpected data format" = "Erreur trousseau: format de données inattendu";
+
+/* Explanation/notification when a long-running operation was cancelled by user */
+"[Progress/CancellationReason] Cancelled by user" = "Annulé par l'utilisateur";
+
+/* Error message when a long-running operation was cancelled due to the lack of free memory (RAM). */
+"[Progress/CancellationReason/lowMemory]" = "Mémoire insuffisante pour continuer.\nCela peut se produire avec des bases de données volumineuse ou des paramètres de base de données trop ambitieux (paramètre de mémoire Argon2).";
+
+/* A description/subtitle for Settings/AppLockTimeout options that trigger when the user has been idle for a while. For example: 'AppLock Timeout: 3 seconds (After last interaction) */
+"[Settings/AppLockTimeout/description] After last interaction" = "Après la dernière interaction";
+
+/* A description/subtitle for Settings/AppLock/Timeout options that trigger when the app is minimized. For example: 'AppLock Timeout: 3 seconds (After leaving the app) */
+"[Settings/AppLockTimeout/description] After leaving the app" = "Après avoir quitté l'application";
+
+/* An option in Settings. Will be shown as 'App Lock: Timeout: Immediately' */
+"[Settings/AppLockTimeout/fullTitle] Immediately" = "Immédiatement";
+
+/* An option in Settings. Will be shown as 'App Lock: Timeout: Never' */
+"[Settings/AppLockTimeout/fullTitle] Never" = "Jamais";
+
+/* An option in Settings. Will be shown as 'App Lock: Timeout: Immediately' */
+"[Settings/AppLockTimeout/shortTitle] Immediately" = "Immédiatement";
+
+/* An option in Settings. Will be shown as 'App Lock: Timeout: Never' */
+"[Settings/AppLockTimeout/shortTitle] Never" = "Jamais";
+
+/* An option in Settings. Please keep it short. Will be shown as 'Keep Backup Files: Forever' */
+"[Settings/BackupKeepingDuration/shortTitle] Forever" = "Pour toujours";
+
+/* An option in Settings. Will be shown as 'Clipboard Timeout: Never' */
+"[Settings/ClipboardTimeout/fullTitle] Never" = "Jamais";
+
+/* An option in Settings. Will be shown as 'Clipboard Timeout: Never' */
+"[Settings/ClipboardTimeout/shortTitle] Never" = "Jamais";
+
+/* A description/subtitle for the 'DatabaseLockTimeout: Immediately'. */
+"[Settings/DatabaseLockTimeout/description] When leaving the app" = "En quittant l'application";
+
+/* An option in Settings. Will be shown as 'Database Lock: Timeout: Immediately' */
+"[Settings/DatabaseLockTimeout/fullTitle] Immediately" = "Immédiatement";
+
+/* An option in Settings. Will be shown as 'Database Lock: Timeout: Never' */
+"[Settings/DatabaseLockTimeout/fullTitle] Never" = "Jamais";
+
+/* An option in Settings. Will be shown as 'Database Lock: Timeout: Immediately' */
+"[Settings/DatabaseLockTimeout/shortTitle] Immediately" = "Immédiatement";
+
+/* An option in Settings. Will be shown as 'Database Lock: Timeout: Never' */
+"[Settings/DatabaseLockTimeout/shortTitle] Never" = "Jamais";
+
+/* An option in Group Viewer settings. Refers fo the most recent time when the entry was modified. Will be shown as 'Entry Subtitle: Last Modified Date'. */
+"[Settings/EntryListDetail/longTitle] Last Modified Date" = "Dernière modification";
+
+/* An option in Group Viewer settings. Will be shown as 'Entry Subtitle: None', meanining that no entry details will be shown in any lists. */
+"[Settings/EntryListDetail/longTitle] None" = "Aucune";
+
+/* An option in Group Viewer settings. Refers to comments/notes field of the entry. Will be shown as 'Entry Subtitle: Notes'. */
+"[Settings/EntryListDetail/longTitle] Notes" = "Remarques";
+
+/* An option in Group Viewer settings. Will be shown as 'Entry Subtitle: Password'. */
+"[Settings/EntryListDetail/longTitle] Password" = "Mot de passe";
+
+/* An option in Group Viewer settings. Will be shown as 'Entry Subtitle: URL'. */
+"[Settings/EntryListDetail/longTitle] URL" = "URL";
+
+/* An option in Group Viewer settings. It refers to login information rather than person's name. Will be shown as 'Entry Subtitle: User Name'. */
+"[Settings/EntryListDetail/longTitle] User Name" = "Nom d'utilisateur";
+
+/* Human-readable file location. The file is situated either online / in cloud storage, or on the same device, but in some other app. Example: 'File Location: Cloud storage / Another app' */
+"[URLReference/Location] Cloud storage / Another app" = "Stockage Cloud / Une autre application";
+
+/* Human-readable file location: the file is on device, inside the app sandbox. 'Backup' is a dedicated directory for database backup files. Example: 'File Location: Internal backup' */
+"[URLReference/Location] Internal backup" = "Sauvegarde interne";
+
+/* Human-readable file location: the file is on device, inside the app sandbox. 'Inbox' is a special directory for files that are being imported. Can be also 'Internal import'. Example: 'File Location: Internal inbox' */
+"[URLReference/Location] Internal inbox" = "Boîte de réception interne";
+
+/* Human-readable file location: the file is on device, inside the app sandbox. Example: 'File Location: Local copy' */
+"[URLReference/Location] Local copy" = "Copie locale";
+

--- a/KeePassiumLib/KeePassiumLib/util/Clipboard.swift
+++ b/KeePassiumLib/KeePassiumLib/util/Clipboard.swift
@@ -32,7 +32,7 @@ public class Clipboard {
     }
     
     private func insert(items: [[String: Any]], timeout: Double?) {
-        if let timeout = timeout {
+        if let timeout = timeout, timeout > 0.0 {
             UIPasteboard.general.setItems(
                 items,
                 options: [

--- a/KeePassiumLib/KeePassiumLib/util/DatabaseSettings.swift
+++ b/KeePassiumLib/KeePassiumLib/util/DatabaseSettings.swift
@@ -78,7 +78,7 @@ public class DatabaseSettings: Eraseable, Codable {
     }
     
     public func maybeSetMasterKey(_ key: CompositeKey) {
-        guard isRememberKeyFile ?? Settings.current.isRememberDatabaseKey else { return }
+        guard isRememberMasterKey ?? Settings.current.isRememberDatabaseKey else { return }
         guard key.state >= .combinedComponents else { return }
         setMasterKey(key)
     }


### PR DESCRIPTION
Docs: update changelog
Release: version bump to 1.11.54
Fix(viewEntry): always decorate password fields as protected (libkeepass/pykeepass#194)
Fix(L10n): minor L10n fixes
Feat(L10n): add French translation
Fix(L10n): exclude support email from localizable strings
Fix(db): access moved items after the move, not before
Fix(fileType): recognition of mixed-case file extensions
Docs(db2): add description to some Meta2 fields
Fix(db): update Meta.masterKeyChangedTime when changing the master key
Fix(db): more timestamp updates when accessing/moving/deleting DB items
Fix(viewEntry): colored asterisks after re-hiding protected text
Feat(fileKeeper): custom resolution of import file name conflicts (closes #91)
Refactor(fileKeeper): simplify clearInbox()
Chore(fileKeeper): add navigation marks
Fix(fileKeeper): trashing randomly fails, delete permanently instead
Fix(dbm): changed master key is not remembered when it should
Fix(dbChoser): backup files should not count towards free DB limit
Fix: infinite Clipboard Timeout was treated as immediate
Chore: fix deprecation warning for dimsBackgroundDuringPresentation
Fix: hard-coded absolute path in contents.xcworkspacedata (fixes #90)